### PR TITLE
Fixed: Bump dependencies

### DIFF
--- a/libcrux-provider/Cargo.toml
+++ b/libcrux-provider/Cargo.toml
@@ -6,25 +6,25 @@ license = "Apache-2.0 OR ISC OR MIT"
 description = "A rustls crypto provider based on libcrux."
 
 [dependencies]
-rustls = { version = "0.23.18" }
+rustls = { version = "0.23.36" }
 
-libcrux = { git = "https://github.com/cryspen/libcrux", rev = "8ebe732" }
-libcrux-sha2 = { git = "https://github.com/cryspen/libcrux", rev = "8ebe732" }
-libcrux-hmac = { git = "https://github.com/cryspen/libcrux", rev = "8ebe732" }
-libcrux-ed25519 = { git = "https://github.com/cryspen/libcrux", rev = "8ebe732" }
-libcrux-traits = { git = "https://github.com/cryspen/libcrux", rev = "8ebe732" }
-libcrux-ml-kem = { git = "https://github.com/cryspen/libcrux", rev = "8ebe732" }
+libcrux = { git = "https://github.com/cryspen/libcrux", rev = "367ce83" }
+libcrux-sha2 = "0.0.5"
+libcrux-hmac = "0.0.5"
+libcrux-ed25519 = "0.0.5"
+libcrux-traits = "0.0.5"
+libcrux-ml-kem = "0.0.6"
 
 der = "0.7"
-hpke-rs = "0.3"
-hpke-rs-crypto = "0.3"
-hpke-rs-rust-crypto = "0.3"
+hpke-rs = "0.5"
+hpke-rs-crypto = "0.4"
+hpke-rs-rust-crypto = "0.4"
 pkcs8 = "0.10.2"
 pkcs1 = "0.7.5"
 pki-types = { package = "rustls-pki-types", version = "1" }
 rand_core = { version = "0.9", features = ["os_rng"] }
-webpki = { package = "rustls-webpki", version = "0.102", features = [
-    "alloc", "aws_lc_rs",
+webpki = { package = "rustls-webpki", version = "0.103", features = [
+    "alloc", 
 ], default-features = false }
 
 [dev-dependencies]

--- a/libcrux-provider/src/hmac.rs
+++ b/libcrux-provider/src/hmac.rs
@@ -26,11 +26,11 @@ impl crypto::hmac::Key for Sha256HmacKey {
         }
         data.extend_from_slice(last);
 
-        let result = libcrux::hmac::hmac(libcrux::hmac::Algorithm::Sha256, &self.0, &data, None);
+        let result = libcrux_hmac::hmac(libcrux_hmac::Algorithm::Sha256, &self.0, &data, None);
         crypto::hmac::Tag::new(&result[..])
     }
 
     fn tag_len(&self) -> usize {
-        libcrux_hmac::tag_size(libcrux::hmac::Algorithm::Sha256)
+        libcrux_hmac::tag_size(libcrux_hmac::Algorithm::Sha256)
     }
 }

--- a/libcrux-provider/src/verify.rs
+++ b/libcrux-provider/src/verify.rs
@@ -4,9 +4,9 @@ use libcrux::signature::{
     verify, DigestAlgorithm, EcDsaP256Signature, Ed25519Signature, Signature,
 };
 use rustls::crypto::WebPkiSupportedAlgorithms;
-use rustls::pki_types::{AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
+use rustls::pki_types::{alg_id, AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
 use rustls::SignatureScheme;
-use webpki::{alg_id, aws_lc_rs::RSA_PKCS1_2048_8192_SHA256 as AWS_LC_RSA_PKCS1_SHA256};
+use webpki::{aws_lc_rs::RSA_PKCS1_2048_8192_SHA256 as AWS_LC_RSA_PKCS1_SHA256};
 
 pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[


### PR DESCRIPTION
Hello everyone,

this PR bumps all dependencies to the newest version possible. This fixes in particular #5 as hpke v0.0.5 can be build.
The only change to the code is, that alg_id is now imported from rustls::pki_types instead of webpki.