### PR TITLE
Fixed: Use new libcrux crate

### DIFF
--- a/demo-server/src/main.rs
+++ b/demo-server/src/main.rs
@@ -33,7 +33,7 @@ async fn index(hbs: web::Data<handlebars::Handlebars<'_>>, req: HttpRequest) -> 
     let named = req.conn_data::<NamedGroup>().unwrap();
     let group_name = named_group_string(named);
 
-    let is_pq = *named == NamedGroup::Unknown(0x11ec);
+    let is_pq = *named == NamedGroup::X25519MLKEM768;
 
     #[derive(serde::Serialize)]
     struct Data {
@@ -169,7 +169,7 @@ impl std::error::Error for Error {
 
 fn named_group_string(group: &NamedGroup) -> String {
     match group {
-        NamedGroup::Unknown(0x11ec) => "Hybrid_ML-KEM_X25519".to_string(),
+        NamedGroup::X25519MLKEM768 => "Hybrid_ML-KEM_X25519".to_string(),
         other => format!("{other:?}"),
     }
 }

--- a/libcrux-provider/Cargo.toml
+++ b/libcrux-provider/Cargo.toml
@@ -8,17 +8,12 @@ description = "A rustls crypto provider based on libcrux."
 [dependencies]
 rustls = { version = "0.23.36" }
 
-libcrux = { git = "https://github.com/cryspen/libcrux", rev = "367ce83" }
-libcrux-sha2 = "0.0.5"
-libcrux-hmac = "0.0.5"
-libcrux-ed25519 = "0.0.5"
-libcrux-traits = "0.0.5"
-libcrux-ml-kem = "0.0.6"
+libcrux = "0.0.3"
+libcrux-traits = "0.0.6"
+
+hpke-rs = { version = "0.5", features = ["hazmat"]}
 
 der = "0.7"
-hpke-rs = "0.5"
-hpke-rs-crypto = "0.4"
-hpke-rs-rust-crypto = "0.4"
 pkcs8 = "0.10.2"
 pkcs1 = "0.7.5"
 pki-types = { package = "rustls-pki-types", version = "1" }
@@ -35,4 +30,4 @@ webpki-roots = "0.26"
 
 [features]
 default = ["std"]
-std = ["hpke-rs/std", "hpke-rs-crypto/std", "pkcs8/std", "rustls/std"]
+std = ["pkcs8/std", "rustls/std"]

--- a/libcrux-provider/src/aead.rs
+++ b/libcrux-provider/src/aead.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use alloc::boxed::Box;
 
 use rustls::{
@@ -10,20 +12,27 @@ use rustls::{
     ConnectionTrafficSecrets, ContentType, ProtocolVersion,
 };
 
-use libcrux::aead::{self, Chacha20Key, Key, Tag};
+use libcrux::{algorithms::aes_gcm::Aead, primitives::aead};
+use libcrux::algorithms::chacha20poly1305;
 
-const TAG_LEN: usize = aead::Algorithm::Chacha20Poly1305.tag_size();
+
+
+pub enum LibcruxAeadKey {
+    Chacha20Poly1305([u8; chacha20poly1305::KEY_LEN]),
+}
 
 pub struct Chacha20Poly1305;
 
 impl Tls13AeadAlgorithm for Chacha20Poly1305 {
     fn encrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageEncrypter> {
-        let key = Key::Chacha20Poly1305(Chacha20Key(key.as_ref().try_into().unwrap()));
+        let key: [u8; chacha20poly1305::KEY_LEN] = key.as_ref().try_into().unwrap();
+        let key = LibcruxAeadKey::Chacha20Poly1305(key);
         Box::new(Tls13Cipher(key, iv))
     }
 
     fn decrypter(&self, key: AeadKey, iv: Iv) -> Box<dyn MessageDecrypter> {
-        let key = Key::Chacha20Poly1305(Chacha20Key(key.as_ref().try_into().unwrap()));
+        let key: [u8; chacha20poly1305::KEY_LEN] = key.as_ref().try_into().unwrap();
+        let key = LibcruxAeadKey::Chacha20Poly1305(key);
         Box::new(Tls13Cipher(key, iv))
     }
 
@@ -42,12 +51,14 @@ impl Tls13AeadAlgorithm for Chacha20Poly1305 {
 
 impl Tls12AeadAlgorithm for Chacha20Poly1305 {
     fn encrypter(&self, key: AeadKey, iv: &[u8], _: &[u8]) -> Box<dyn MessageEncrypter> {
-        let key = Key::Chacha20Poly1305(Chacha20Key(key.as_ref().try_into().unwrap()));
+        let key: [u8; chacha20poly1305::KEY_LEN] = key.as_ref().try_into().unwrap();
+        let key = LibcruxAeadKey::Chacha20Poly1305(key);
         Box::new(Tls12Cipher(key, Iv::copy(iv)))
     }
 
     fn decrypter(&self, key: AeadKey, iv: &[u8]) -> Box<dyn MessageDecrypter> {
-        let key = Key::Chacha20Poly1305(Chacha20Key(key.as_ref().try_into().unwrap()));
+        let key: [u8; chacha20poly1305::KEY_LEN] = key.as_ref().try_into().unwrap();
+        let key = LibcruxAeadKey::Chacha20Poly1305(key);
         Box::new(Tls12Cipher(key, Iv::copy(iv)))
     }
 
@@ -74,7 +85,7 @@ impl Tls12AeadAlgorithm for Chacha20Poly1305 {
     }
 }
 
-struct Tls13Cipher(Key, Iv);
+struct Tls13Cipher(LibcruxAeadKey, Iv);
 
 impl MessageEncrypter for Tls13Cipher {
     fn encrypt(
@@ -87,24 +98,39 @@ impl MessageEncrypter for Tls13Cipher {
 
         payload.extend_from_chunks(&m.payload);
         payload.extend_from_slice(&m.typ.to_array());
+        let plaintext = payload.as_ref().to_vec();
+
         let nonce = Nonce::new(&self.1, seq);
         let aad = make_tls13_aad(total_len);
-        let iv = libcrux::aead::Iv(nonce.0);
+        let mut ciphertext = vec![0u8; plaintext.len()];
+
+        let key = match &self.0 {
+            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::EncryptError)?,
+        };
+
+        let mut tag = vec![0u8; key.algo().tag_len()];
+
+        let tag_ref = aead::TagMut::new_for_algo(*key.algo(), &mut tag)
+            .map_err(|_| rustls::Error::EncryptError)?;
+
+        let nonce = aead::NonceRef::new_for_algo(*key.algo(), &nonce.0)
+            .map_err(|_| rustls::Error::EncryptError)?;
+
+        key.encrypt(&mut ciphertext, tag_ref, nonce, &aad, &plaintext)
+            .map_err(|_| rustls::Error::EncryptError)?;
+
+        let mut payload = PrefixedPayload::with_capacity(total_len);
+        payload.extend_from_slice(&ciphertext);
+        payload.extend_from_slice(tag.as_ref());
 
         // self.0
         //     .encrypt_in_place(&nonce, &aad, &mut EncryptBufferAdapter(&mut payload))
 
-        let out = libcrux::aead::encrypt(&self.0, payload.as_mut(), iv, &aad)
-            .map_err(|_| rustls::Error::EncryptError)
-            .map(|tag| {
-                payload.extend_from_slice(tag.as_ref());
-                OutboundOpaqueMessage::new(
-                    ContentType::ApplicationData,
-                    ProtocolVersion::TLSv1_2,
-                    payload,
-                )
-            });
-        out
+        Ok(OutboundOpaqueMessage::new(
+            ContentType::ApplicationData,
+            ProtocolVersion::TLSv1_2,
+            payload,
+        ))
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -118,31 +144,42 @@ impl MessageDecrypter for Tls13Cipher {
         mut m: InboundOpaqueMessage<'a>,
         seq: u64,
     ) -> Result<InboundPlainMessage<'a>, rustls::Error> {
+        let key = match &self.0 {
+            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::DecryptError)?,
+        };
+
         let payload_and_tag = &mut m.payload;
         let total_len = payload_and_tag.len();
-        let payload_and_tag_len = payload_and_tag.len();
-        if payload_and_tag_len < TAG_LEN {
+        let tag_len = key.algo().tag_len();
+        if total_len < tag_len {
             return Err(rustls::Error::DecryptError);
         }
 
-        let (payload, tag) = payload_and_tag.split_at_mut(payload_and_tag_len - TAG_LEN);
+        let (payload, tag) = payload_and_tag.split_at_mut(total_len - tag_len);
 
         let nonce = Nonce::new(&self.1, seq);
         let aad = make_tls13_aad(total_len);
-        let iv = libcrux::aead::Iv(nonce.0);
-        let tag = Tag::from_slice(tag).unwrap();
+        let mut plaintext = vec![0u8; payload.len()];
 
-        libcrux::aead::decrypt(&self.0, payload, iv, &aad, &tag)
+        let tag = aead::TagRef::new_for_algo(*key.algo(), tag)
+            .map_err(|_| rustls::Error::DecryptError)?;
+
+        let nonce = aead::NonceRef::new_for_algo(*key.algo(), &nonce.0)
+            .map_err(|_| rustls::Error::DecryptError)?;
+
+        key.decrypt(&mut plaintext, nonce, &aad, payload, tag)
             .map_err(|_| rustls::Error::DecryptError)?;
 
         m.payload
-            .truncate(m.payload.len() - TAG_LEN);
+            .truncate(m.payload.len() - tag_len);
+
+        m.payload.copy_from_slice(&plaintext);
 
         m.into_tls13_unpadded_message()
     }
 }
 
-struct Tls12Cipher(Key, Iv);
+struct Tls12Cipher(LibcruxAeadKey, Iv);
 
 impl MessageEncrypter for Tls12Cipher {
     fn encrypt(
@@ -154,13 +191,35 @@ impl MessageEncrypter for Tls12Cipher {
         let mut payload = PrefixedPayload::with_capacity(total_len);
 
         payload.extend_from_chunks(&m.payload);
+        let plaintext = payload.as_ref().to_vec();
+
         let nonce = Nonce::new(&self.1, seq);
         let aad = make_tls12_aad(seq, m.typ, m.version, m.payload.len());
-        let iv = libcrux::aead::Iv(nonce.0);
+        let mut ciphertext = vec![0u8; plaintext.len()];
+        
+        let key = match &self.0 {
+            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::EncryptError)?,
+        };
 
-        libcrux::aead::encrypt(&self.0, payload.as_mut(), iv, &aad)
-            .map_err(|_| rustls::Error::EncryptError)
-            .map(|_| OutboundOpaqueMessage::new(m.typ, m.version, payload))
+        let mut tag = vec![0u8; key.algo().tag_len()];
+
+        let tag_ref = aead::TagMut::new_for_algo(*key.algo(), &mut tag)
+            .map_err(|_| rustls::Error::EncryptError)?;
+
+        let nonce = aead::NonceRef::new_for_algo(*key.algo(), &nonce.0)
+            .map_err(|_| rustls::Error::EncryptError)?;
+
+        key.encrypt(&mut ciphertext, tag_ref, nonce, &aad, &plaintext)
+            .map_err(|_| rustls::Error::EncryptError)?;
+
+        let mut payload = PrefixedPayload::with_capacity(total_len);
+        payload.extend_from_slice(&ciphertext);
+
+        Ok(OutboundOpaqueMessage::new(
+            m.typ,
+            m.version,
+            payload,
+        ))
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -174,13 +233,18 @@ impl MessageDecrypter for Tls12Cipher {
         mut m: InboundOpaqueMessage<'a>,
         seq: u64,
     ) -> Result<InboundPlainMessage<'a>, rustls::Error> {
+        let key = match &self.0 {
+            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::DecryptError)?,
+        };
+
         let payload_and_tag = &mut m.payload;
         let payload_and_tag_len = payload_and_tag.len();
-        if payload_and_tag_len < TAG_LEN {
+        let tag_len = key.algo().tag_len();
+        if payload_and_tag_len < tag_len {
             return Err(rustls::Error::DecryptError);
         }
 
-        let (payload, tag) = payload_and_tag.split_at_mut(payload_and_tag_len - TAG_LEN);
+        let (payload, tag) = payload_and_tag.split_at_mut(payload_and_tag_len - tag_len);
         let nonce = Nonce::new(&self.1, seq);
         let aad = make_tls12_aad(
             seq,
@@ -188,15 +252,21 @@ impl MessageDecrypter for Tls12Cipher {
             m.version,
             payload.len() - CHACHAPOLY1305_OVERHEAD,
         );
-        let iv = libcrux::aead::Iv(nonce.0);
-        let tag = Tag::from_slice(tag).unwrap();
+        let mut plaintext = vec![0u8; payload.len()];
 
-        let payload = &mut m.payload;
-        libcrux::aead::decrypt(&self.0, payload.as_mut(), iv, &aad, &tag)
+        let tag = aead::TagRef::new_for_algo(*key.algo(), tag)
+            .map_err(|_| rustls::Error::DecryptError)?;
+
+        let nonce = aead::NonceRef::new_for_algo(*key.algo(), &nonce.0)
+            .map_err(|_| rustls::Error::DecryptError)?;
+
+        key.decrypt(&mut plaintext, nonce, &aad, payload, tag)
             .map_err(|_| rustls::Error::DecryptError)?;
 
         m.payload
-            .truncate(m.payload.len() - TAG_LEN);
+            .truncate(m.payload.len() - tag_len);
+
+        m.payload.copy_from_slice(&plaintext);
 
         Ok(m.into_plain_message())
     }

--- a/libcrux-provider/src/hash.rs
+++ b/libcrux-provider/src/hash.rs
@@ -1,8 +1,7 @@
 use alloc::boxed::Box;
 use std::sync::Mutex;
 
-use libcrux_sha2 as sha2;
-use libcrux_traits::Digest;
+use libcrux::algorithms::sha2::{self, Digest};
 use rustls::crypto::hash;
 
 pub struct Sha256;

--- a/libcrux-provider/src/hmac.rs
+++ b/libcrux-provider/src/hmac.rs
@@ -1,6 +1,8 @@
 use alloc::boxed::Box;
 
 use rustls::crypto;
+use libcrux::algorithms::sha2 as sha2;
+use libcrux::algorithms::hmac as hmac;
 
 pub struct Sha256Hmac;
 
@@ -10,7 +12,7 @@ impl crypto::hmac::Hmac for Sha256Hmac {
     }
 
     fn hash_output_len(&self) -> usize {
-        libcrux_sha2::SHA256_LENGTH
+        sha2::SHA256_LENGTH
     }
 }
 
@@ -26,11 +28,11 @@ impl crypto::hmac::Key for Sha256HmacKey {
         }
         data.extend_from_slice(last);
 
-        let result = libcrux_hmac::hmac(libcrux_hmac::Algorithm::Sha256, &self.0, &data, None);
+        let result = hmac::hmac(hmac::Algorithm::Sha256, &self.0, &data, None);
         crypto::hmac::Tag::new(&result[..])
     }
 
     fn tag_len(&self) -> usize {
-        libcrux_hmac::tag_size(libcrux_hmac::Algorithm::Sha256)
+        hmac::tag_size(hmac::Algorithm::Sha256)
     }
 }

--- a/libcrux-provider/src/hpke.rs
+++ b/libcrux-provider/src/hpke.rs
@@ -1,19 +1,11 @@
 use alloc::boxed::Box;
 use alloc::string::String;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::fmt::Debug;
-use rand_core::TryRngCore;
-use std::error::Error as StdError;
 
-use libcrux::hpke::aead::AEAD;
-use libcrux::hpke::kdf::KDF;
-use libcrux::hpke::kem::KEM;
-use libcrux::hpke::HPKEConfig;
+use libcrux::protocols::hpke;
+use libcrux::protocols::hpke::libcrux as HPKEProvider;
 
-use hpke_rs_crypto::types::{AeadAlgorithm, KdfAlgorithm, KemAlgorithm};
-use hpke_rs_crypto::HpkeCrypto;
-use hpke_rs_rust_crypto::HpkeRustCrypto;
 use rustls::crypto::hpke::{
     EncapsulatedSecret, Hpke, HpkeOpener, HpkePrivateKey, HpkePublicKey, HpkeSealer, HpkeSuite,
 };
@@ -21,7 +13,7 @@ use rustls::internal::msgs::enums::{
     HpkeAead as HpkeAeadId, HpkeKdf as HpkeKdfId, HpkeKem as HpkeKemId,
 };
 use rustls::internal::msgs::handshake::HpkeSymmetricCipherSuite;
-use rustls::{Error, OtherError};
+use rustls::Error;
 
 /// All supported HPKE suites.
 ///
@@ -35,246 +27,83 @@ pub static ALL_SUPPORTED_SUITES: &[&dyn Hpke] = &[
     DHKEM_X25519_HKDF_SHA256_CHACHA20_POLY1305,
 ];
 
-pub static DHKEM_P256_HKDF_SHA256_AES_128: &LibcruxHpke = &LibcruxHpke(HPKEConfig(
-    libcrux::hpke::Mode::mode_base,
-    KEM::DHKEM_P256_HKDF_SHA256,
-    KDF::HKDF_SHA256,
-    AEAD::AES_128_GCM,
-));
+pub static DHKEM_P256_HKDF_SHA256_AES_128: &LibcruxHpkeConfig = &LibcruxHpkeConfig{
+    mode: hpke::Mode::Base,
+    kem: hpke::hpke_types::KemAlgorithm::DhKemP256,
+    kdf: hpke::hpke_types::KdfAlgorithm::HkdfSha256,
+    aead: hpke::hpke_types::AeadAlgorithm::Aes128Gcm,
+};
 
-pub static DHKEM_P256_HKDF_SHA256_AES_256: &LibcruxHpke = &LibcruxHpke(HPKEConfig(
-    libcrux::hpke::Mode::mode_base,
-    KEM::DHKEM_P256_HKDF_SHA256,
-    KDF::HKDF_SHA256,
-    AEAD::AES_256_GCM,
-));
-
-pub static DHKEM_P256_HKDF_SHA256_CHACHA20_POLY1305: &LibcruxHpke = &LibcruxHpke(HPKEConfig(
-    libcrux::hpke::Mode::mode_base,
-    KEM::DHKEM_P256_HKDF_SHA256,
-    KDF::HKDF_SHA256,
-    AEAD::ChaCha20Poly1305,
-));
-
-pub static DHKEM_X25519_HKDF_SHA256_AES_128: &LibcruxHpke = &LibcruxHpke(HPKEConfig(
-    libcrux::hpke::Mode::mode_base,
-    KEM::DHKEM_X25519_HKDF_SHA256,
-    KDF::HKDF_SHA256,
-    AEAD::AES_128_GCM,
-));
-
-pub static DHKEM_X25519_HKDF_SHA256_AES_256: &LibcruxHpke = &LibcruxHpke(HPKEConfig(
-    libcrux::hpke::Mode::mode_base,
-    KEM::DHKEM_X25519_HKDF_SHA256,
-    KDF::HKDF_SHA256,
-    AEAD::AES_256_GCM,
-));
-
-pub static DHKEM_X25519_HKDF_SHA256_CHACHA20_POLY1305: &LibcruxHpke = &LibcruxHpke(HPKEConfig(
-    libcrux::hpke::Mode::mode_base,
-    KEM::DHKEM_X25519_HKDF_SHA256,
-    KDF::HKDF_SHA256,
-    AEAD::ChaCha20Poly1305,
-));
-
-/// A HPKE suite backed by the [hpke-rs] crate and its rust-crypto cryptography provider.
-///
-/// [hpke-rs]: https://github.com/franziskuskiefer/hpke-rs
-#[derive(Debug)]
-pub struct HpkeRs(HpkeSuite);
-
-impl HpkeRs {
-    fn start(&self) -> Result<hpke_rs::Hpke<HpkeRustCrypto>, Error> {
-        Ok(hpke_rs::Hpke::new(
-            hpke_rs::Mode::Base,
-            KemAlgorithm::try_from(u16::from(self.0.kem)).map_err(other_err)?,
-            KdfAlgorithm::try_from(u16::from(self.0.sym.kdf_id)).map_err(other_err)?,
-            AeadAlgorithm::try_from(u16::from(self.0.sym.aead_id)).map_err(other_err)?,
-        ))
-    }
-}
-
-impl Hpke for HpkeRs {
-    fn seal(
-        &self,
-        info: &[u8],
-        aad: &[u8],
-        plaintext: &[u8],
-        pub_key: &HpkePublicKey,
-    ) -> Result<(EncapsulatedSecret, Vec<u8>), Error> {
-        let pk_r = hpke_rs::HpkePublicKey::new(pub_key.0.clone());
-        let (enc, ciphertext) = self
-            .start()?
-            .seal(&pk_r, info, aad, plaintext, None, None, None)
-            .map_err(other_err)?;
-        Ok((EncapsulatedSecret(enc.to_vec()), ciphertext))
-    }
-
-    fn setup_sealer(
-        &self,
-        info: &[u8],
-        pub_key: &HpkePublicKey,
-    ) -> Result<(EncapsulatedSecret, Box<dyn HpkeSealer + 'static>), Error> {
-        let pk_r = hpke_rs::HpkePublicKey::new(pub_key.0.clone());
-        let (enc, context) = self
-            .start()?
-            .setup_sender(&pk_r, info, None, None, None)
-            .map_err(other_err)?;
-        Ok((
-            EncapsulatedSecret(enc.to_vec()),
-            Box::new(HpkeRsSender { context }),
-        ))
-    }
-
-    fn open(
-        &self,
-        enc: &EncapsulatedSecret,
-        info: &[u8],
-        aad: &[u8],
-        ciphertext: &[u8],
-        secret_key: &HpkePrivateKey,
-    ) -> Result<Vec<u8>, Error> {
-        let sk_r = hpke_rs::HpkePrivateKey::new(secret_key.secret_bytes().to_vec());
-        self.start()?
-            .open(
-                enc.0.as_slice(),
-                &sk_r,
-                info,
-                aad,
-                ciphertext,
-                None,
-                None,
-                None,
-            )
-            .map_err(other_err)
-    }
-
-    fn setup_opener(
-        &self,
-        enc: &EncapsulatedSecret,
-        info: &[u8],
-        secret_key: &HpkePrivateKey,
-    ) -> Result<Box<dyn HpkeOpener + 'static>, Error> {
-        let sk_r = hpke_rs::HpkePrivateKey::new(secret_key.secret_bytes().to_vec());
-        Ok(Box::new(HpkeRsReceiver {
-            context: self
-                .start()?
-                .setup_receiver(enc.0.as_slice(), &sk_r, info, None, None, None)
-                .map_err(other_err)?,
-        }))
-    }
-
-    fn generate_key_pair(&self) -> Result<(HpkePublicKey, HpkePrivateKey), Error> {
-        let kem_algorithm = match self.0.kem {
-            HpkeKemId::DHKEM_P256_HKDF_SHA256 => KemAlgorithm::DhKemP256,
-            HpkeKemId::DHKEM_X25519_HKDF_SHA256 => KemAlgorithm::DhKem25519,
-            _ => {
-                // Safety: we don't expose HpkeRs static instances for unsupported algorithms.
-                unimplemented!()
-            }
-        };
-
-        let (public_key, secret_key) = HpkeRustCrypto::kem_key_gen(kem_algorithm, &mut HpkeRustCrypto::prng())
-            .map_err(other_err)?;
-
-        Ok((HpkePublicKey(public_key), HpkePrivateKey::from(secret_key)))
-    }
-
-    fn suite(&self) -> HpkeSuite {
-        self.0
-    }
-}
-
-#[derive(Debug)]
-struct HpkeRsSender {
-    context: hpke_rs::Context<HpkeRustCrypto>,
-}
-
-impl HpkeSealer for HpkeRsSender {
-    fn seal(&mut self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, Error> {
-        self.context
-            .seal(aad, plaintext)
-            .map_err(other_err)
-    }
-}
-
-#[derive(Debug)]
-struct HpkeRsReceiver {
-    context: hpke_rs::Context<HpkeRustCrypto>,
-}
-
-impl HpkeOpener for HpkeRsReceiver {
-    fn open(&mut self, aad: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, Error> {
-        self.context
-            .open(aad, ciphertext)
-            .map_err(other_err)
-    }
-}
+pub static DHKEM_P256_HKDF_SHA256_AES_256: &LibcruxHpkeConfig = &LibcruxHpkeConfig {
+    mode: hpke::Mode::Base,
+    kem: hpke::hpke_types::KemAlgorithm::DhKemP256,
+    kdf: hpke::hpke_types::KdfAlgorithm::HkdfSha256,
+    aead: hpke::hpke_types::AeadAlgorithm::Aes256Gcm,
+};
+pub static DHKEM_P256_HKDF_SHA256_CHACHA20_POLY1305: &LibcruxHpkeConfig = &LibcruxHpkeConfig {
+    mode: hpke::Mode::Base,
+    kem: hpke::hpke_types::KemAlgorithm::DhKemP256,
+    kdf: hpke::hpke_types::KdfAlgorithm::HkdfSha256,
+    aead: hpke::hpke_types::AeadAlgorithm::ChaCha20Poly1305,
+};
+pub static DHKEM_X25519_HKDF_SHA256_AES_128: &LibcruxHpkeConfig = &LibcruxHpkeConfig {
+    mode: hpke::Mode::Base,
+    kem: hpke::hpke_types::KemAlgorithm::DhKem25519,
+    kdf: hpke::hpke_types::KdfAlgorithm::HkdfSha256,
+    aead: hpke::hpke_types::AeadAlgorithm::Aes128Gcm,
+};
+pub static DHKEM_X25519_HKDF_SHA256_AES_256: &LibcruxHpkeConfig = &LibcruxHpkeConfig {
+    mode: hpke::Mode::Base,
+    kem: hpke::hpke_types::KemAlgorithm::DhKem25519,
+    kdf: hpke::hpke_types::KdfAlgorithm::HkdfSha256,
+    aead: hpke::hpke_types::AeadAlgorithm::Aes256Gcm,
+};
+pub static DHKEM_X25519_HKDF_SHA256_CHACHA20_POLY1305: &LibcruxHpkeConfig = &LibcruxHpkeConfig {
+    mode: hpke::Mode::Base,
+    kem: hpke::hpke_types::KemAlgorithm::DhKem25519,
+    kdf: hpke::hpke_types::KdfAlgorithm::HkdfSha256,
+    aead: hpke::hpke_types::AeadAlgorithm::ChaCha20Poly1305,
+};
 
 #[derive(Debug)]
 struct LibcruxHpkeSealer {
-    context: (
-        libcrux::hpke::aead::Key,
-        libcrux::hpke::aead::Nonce,
-        u32,
-        Vec<u8>,
-    ),
-    config: libcrux::hpke::HPKEConfig,
+    context: hpke::Context<HPKEProvider::HpkeLibcrux>,
 }
 
 impl HpkeSealer for LibcruxHpkeSealer {
     fn seal(&mut self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, Error> {
-        let mut context = (
-            libcrux::hpke::aead::Key::new(),
-            libcrux::hpke::aead::Nonce::new(),
-            0,
-            Vec::new(),
-        );
-        core::mem::swap(&mut self.context, &mut context);
-
-        let (ciphertext, mut context) =
-            libcrux::hpke::ContextS_Seal(self.config.3, context, aad, plaintext)
-                .map_err(|_| Error::General(String::from("hpke seal error")))?;
-        core::mem::swap(&mut self.context, &mut context);
-
-        Ok(ciphertext)
+        self.context.seal(aad, plaintext)
+            .map_err(|_| Error::General(String::from("hpke seal error")))
     }
 }
 
 #[derive(Debug)]
 struct LibcruxHpkeOpener {
-    context: (
-        libcrux::hpke::aead::Key,
-        libcrux::hpke::aead::Nonce,
-        u32,
-        Vec<u8>,
-    ),
-    config: libcrux::hpke::HPKEConfig,
+    context: hpke::Context<HPKEProvider::HpkeLibcrux>,
 }
 
 impl HpkeOpener for LibcruxHpkeOpener {
     fn open(&mut self, aad: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, Error> {
-        let mut context = (
-            libcrux::hpke::aead::Key::new(),
-            libcrux::hpke::aead::Nonce::new(),
-            0,
-            Vec::new(),
-        );
-        core::mem::swap(&mut self.context, &mut context);
-
-        let (plaintext, mut context) =
-            libcrux::hpke::ContextR_Open(self.config.3, context, aad, ciphertext)
-                .map_err(|_| Error::General(String::from("hpke open error")))?;
-
-        core::mem::swap(&mut self.context, &mut context);
-        Ok(plaintext)
+        self.context.open(aad, ciphertext)
+            .map_err(|_| Error::General(String::from("hpke open error")))
     }
 }
 
 #[derive(Debug)]
-pub struct LibcruxHpke(libcrux::hpke::HPKEConfig);
+pub struct LibcruxHpkeConfig {
+    mode: hpke::Mode,
+    kem: hpke::hpke_types::KemAlgorithm,
+    kdf: hpke::hpke_types::KdfAlgorithm,
+    aead: hpke::hpke_types::AeadAlgorithm,
+}
 
-impl Hpke for LibcruxHpke {
+impl From<&LibcruxHpkeConfig> for hpke::Hpke<HPKEProvider::HpkeLibcrux> {
+    fn from(value: &LibcruxHpkeConfig) -> Self {
+        Self::new(value.mode, value.kem, value.kdf, value.aead)
+    }
+}
+
+impl Hpke for LibcruxHpkeConfig {
     fn seal(
         &self,
         info: &[u8],
@@ -282,14 +111,14 @@ impl Hpke for LibcruxHpke {
         plaintext: &[u8],
         pub_key: &HpkePublicKey,
     ) -> Result<(EncapsulatedSecret, Vec<u8>), Error> {
-        let mut randomness = alloc::vec![0u8; libcrux::hpke::kem::Nsecret(self.0 .1)];
-        rand_core::OsRng.try_fill_bytes(&mut randomness).unwrap();
 
-        libcrux::hpke::HpkeSeal(
-            self.0, &pub_key.0, info, aad, plaintext, None, None, None, randomness,
-        )
-        .map_err(|_| Error::General(alloc::string::String::from("hpke seal error")))
-        .map(|ctxt| (EncapsulatedSecret(ctxt.0), ctxt.1))
+        let mut config = hpke::Hpke::<HPKEProvider::HpkeLibcrux>::from(self);
+
+        let pk_r = hpke::HpkePublicKey::from(pub_key.0.as_slice());
+
+        config.seal(&pk_r, info, aad, plaintext, None, None, None)
+            .map_err(|_| Error::General(alloc::string::String::from("hpke seal error")))
+            .map(|ctxt| (EncapsulatedSecret(ctxt.0), ctxt.1))
     }
 
     fn setup_sealer(
@@ -297,17 +126,17 @@ impl Hpke for LibcruxHpke {
         info: &[u8],
         pub_key: &HpkePublicKey,
     ) -> Result<(EncapsulatedSecret, Box<dyn HpkeSealer + 'static>), Error> {
-        let mut randomness = alloc::vec![0u8; libcrux::hpke::kem::Nsecret(self.0 .1)];
-        rand_core::OsRng.try_fill_bytes(&mut randomness).unwrap();
+        let mut config = hpke::Hpke::<HPKEProvider::HpkeLibcrux>::from(self);
 
-        let (kem_ctxt, ctx) = libcrux::hpke::SetupBaseS(self.0, &pub_key.0, info, randomness)
+        let pk_r = hpke::HpkePublicKey::from(pub_key.0.as_slice());
+
+        let (kem_ctxt, ctx) = config.setup_sender(&pk_r, info, None, None, None)
             .map_err(|_| Error::General(alloc::string::String::from("hpke setup sealer error")))?;
 
         Ok((
             EncapsulatedSecret(kem_ctxt),
             Box::new(LibcruxHpkeSealer {
                 context: ctx,
-                config: self.0,
             }),
         ))
     }
@@ -320,17 +149,12 @@ impl Hpke for LibcruxHpke {
         ciphertext: &[u8],
         secret_key: &HpkePrivateKey,
     ) -> Result<Vec<u8>, Error> {
-        libcrux::hpke::HpkeOpen(
-            self.0,
-            &libcrux::hpke::HPKECiphertext(enc.0.clone(), Vec::from(ciphertext)),
-            secret_key.secret_bytes(),
-            info,
-            aad,
-            None,
-            None,
-            None,
-        )
-        .map_err(|_| Error::General(alloc::string::String::from("hpke open error")))
+        let config = hpke::Hpke::<HPKEProvider::HpkeLibcrux>::from(self);
+
+        let sk_r = hpke::HpkePrivateKey::from(secret_key.secret_bytes());
+
+        config.open(&enc.0, &sk_r, info, aad, ciphertext, None, None, None)
+            .map_err(|_| Error::General(alloc::string::String::from("hpke open error")))
     }
 
     fn setup_opener(
@@ -339,45 +163,49 @@ impl Hpke for LibcruxHpke {
         info: &[u8],
         secret_key: &HpkePrivateKey,
     ) -> Result<Box<dyn HpkeOpener + 'static>, Error> {
-        let ctx = libcrux::hpke::SetupBaseR(self.0, &enc.0, secret_key.secret_bytes(), info)
+        let config = hpke::Hpke::<HPKEProvider::HpkeLibcrux>::from(self);
+
+        let sk_r = hpke::HpkePrivateKey::from(secret_key.secret_bytes());
+
+        
+        let ctx = config.setup_receiver(&enc.0, &sk_r, info, None, None, None)
             .map_err(|_| Error::General(alloc::string::String::from("hpke setup opener error")))?;
 
         Ok(Box::new(LibcruxHpkeOpener {
             context: ctx,
-            config: self.0,
         }))
     }
 
     fn generate_key_pair(&self) -> Result<(HpkePublicKey, HpkePrivateKey), Error> {
-        let mut randomness = alloc::vec![0u8; libcrux::hpke::kem::Nsecret(self.0 .1)];
-        rand_core::OsRng.try_fill_bytes(&mut randomness).unwrap();
+        let mut config = hpke::Hpke::<HPKEProvider::HpkeLibcrux>::from(self);
 
-        libcrux::hpke::kem::GenerateKeyPair(self.0 .1, randomness)
+        config.generate_key_pair()
             .map_err(|_| Error::General(String::from("hpke kem keygen error")))
-            .map(|(sk, pk)| (HpkePublicKey(pk), HpkePrivateKey::from(sk)))
+            .map(|pair| pair.into_keys())
+            .map(|(sk, pk)| (HpkePublicKey(pk.as_slice().to_vec()), HpkePrivateKey::from(sk.as_slice().to_vec())))
     }
 
     fn suite(&self) -> HpkeSuite {
-        let kem = match self.0 .1 {
-            KEM::DHKEM_P256_HKDF_SHA256 => HpkeKemId::DHKEM_P256_HKDF_SHA256,
-            KEM::DHKEM_P384_HKDF_SHA384 => HpkeKemId::DHKEM_P384_HKDF_SHA384,
-            KEM::DHKEM_P521_HKDF_SHA512 => HpkeKemId::DHKEM_P521_HKDF_SHA512,
-            KEM::DHKEM_X25519_HKDF_SHA256 => HpkeKemId::DHKEM_X25519_HKDF_SHA256,
-            KEM::DHKEM_X448_HKDF_SHA512 => HpkeKemId::DHKEM_X448_HKDF_SHA512,
+        let kem = match self.kem {
+            hpke::hpke_types::KemAlgorithm::DhKemP256 => HpkeKemId::DHKEM_P256_HKDF_SHA256,
+            hpke::hpke_types::KemAlgorithm::DhKemP384 => HpkeKemId::DHKEM_P384_HKDF_SHA384,
+            hpke::hpke_types::KemAlgorithm::DhKemP521 => HpkeKemId::DHKEM_P521_HKDF_SHA512,
+            hpke::hpke_types::KemAlgorithm::DhKem25519 => HpkeKemId::DHKEM_X25519_HKDF_SHA256,
+            hpke::hpke_types::KemAlgorithm::DhKem448 => HpkeKemId::DHKEM_X448_HKDF_SHA512,
             _ => unimplemented!(),
         };
 
-        let kdf_id = match self.0 .2 {
-            KDF::HKDF_SHA256 => HpkeKdfId::HKDF_SHA256,
-            KDF::HKDF_SHA384 => HpkeKdfId::HKDF_SHA384,
-            KDF::HKDF_SHA512 => HpkeKdfId::HKDF_SHA512,
+        let kdf_id = match self.kdf {
+            hpke::hpke_types::KdfAlgorithm::HkdfSha256 => HpkeKdfId::HKDF_SHA256,
+            hpke::hpke_types::KdfAlgorithm::HkdfSha384 => HpkeKdfId::HKDF_SHA384,
+            hpke::hpke_types::KdfAlgorithm::HkdfSha512 => HpkeKdfId::HKDF_SHA512,
         };
 
-        let aead_id = match self.0 .3 {
-            AEAD::AES_128_GCM => HpkeAeadId::AES_128_GCM,
-            AEAD::AES_256_GCM => HpkeAeadId::AES_256_GCM,
-            AEAD::ChaCha20Poly1305 => HpkeAeadId::CHACHA20_POLY_1305,
-            AEAD::Export_only => HpkeAeadId::EXPORT_ONLY,
+        let aead_id = match self.aead {
+            hpke::hpke_types::AeadAlgorithm::Aes128Gcm => HpkeAeadId::AES_128_GCM,
+            hpke::hpke_types::AeadAlgorithm::Aes256Gcm => HpkeAeadId::AES_256_GCM,
+            hpke::hpke_types::AeadAlgorithm::ChaCha20Poly1305 => HpkeAeadId::CHACHA20_POLY_1305,
+            hpke::hpke_types::AeadAlgorithm::HpkeExport => HpkeAeadId::EXPORT_ONLY,
         };
 
         HpkeSuite {
@@ -385,16 +213,6 @@ impl Hpke for LibcruxHpke {
             sym: HpkeSymmetricCipherSuite { kdf_id, aead_id },
         }
     }
-}
-
-#[cfg(feature = "std")]
-fn other_err(err: impl StdError + Send + Sync + 'static) -> Error {
-    Error::Other(OtherError(Arc::new(err)))
-}
-
-#[cfg(not(feature = "std"))]
-fn other_err(err: impl Send + Sync + 'static) -> Error {
-    Error::General(alloc::format!("{}", err));
 }
 
 #[cfg(test)]

--- a/libcrux-provider/src/kx.rs
+++ b/libcrux-provider/src/kx.rs
@@ -1,25 +1,26 @@
 use alloc::boxed::Box;
 use alloc::string::String;
-use alloc::vec::Vec;
 
-use libcrux::ecdh;
+use libcrux::algorithms::curve25519;
 
+use libcrux_traits::ecdh::owned::EcdhOwned;
 use rustls::crypto::{self, SupportedKxGroup as _};
 use rand_core::TryRngCore;
 
 use crate::pq::X25519MlKem768;
 
-pub struct KeyExchange {
-    priv_key: Vec<u8>,
-    pub_key: Vec<u8>,
+pub struct X25519KeyExchange {
+    priv_key: [u8; 32],
+    pub_key: [u8; 32],
 }
 
-impl crypto::ActiveKeyExchange for KeyExchange {
+impl crypto::ActiveKeyExchange for X25519KeyExchange {
     fn complete(
-        self: Box<KeyExchange>,
+        self: Box<X25519KeyExchange>,
         peer: &[u8],
     ) -> Result<crypto::SharedSecret, rustls::Error> {
-        let shared_secret = ecdh::derive(ecdh::Algorithm::X25519, peer, self.priv_key)
+        let peer: [u8; 32] = peer.try_into().map_err(|_| rustls::Error::General(String::from("ecdh derive error")))?;
+        let shared_secret = curve25519::X25519::derive_ecdh(&peer, &self.priv_key)
             .map_err(|_| rustls::Error::General(String::from("ecdh derive error")))?;
 
         Ok(crypto::SharedSecret::from(&shared_secret[..]))
@@ -35,8 +36,8 @@ impl crypto::ActiveKeyExchange for KeyExchange {
 }
 
 pub const ALL_KX_GROUPS: &[&dyn crypto::SupportedKxGroup] = &[
-    &X25519 as &dyn crypto::SupportedKxGroup,
     &X25519MlKem768 as &dyn crypto::SupportedKxGroup,
+    &X25519 as &dyn crypto::SupportedKxGroup,
 ];
 
 #[derive(Debug)]
@@ -44,10 +45,11 @@ pub struct X25519;
 
 impl crypto::SupportedKxGroup for X25519 {
     fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
-        let (priv_key, pub_key) = ecdh::key_gen(ecdh::Algorithm::X25519, &mut rand_core::OsRng.unwrap_mut())
-            .map_err(|_| rustls::Error::General(String::from("ecdh keygen error")))?;
+        let mut rand: [u8; 32] = [0u8; 32];
+        rand_core::OsRng.try_fill_bytes(&mut rand).map_err(|_| rustls::Error::FailedToGetRandomBytes)?;
+        let (pub_key, priv_key) = curve25519::X25519::generate_pair(&rand).map_err(|_| rustls::Error::General(String::from("ecdh keygen error")))?;
 
-        Ok(Box::new(KeyExchange { pub_key, priv_key }))
+        Ok(Box::new(X25519KeyExchange { pub_key, priv_key }))
     }
 
     fn name(&self) -> rustls::NamedGroup {

--- a/libcrux-provider/src/pq.rs
+++ b/libcrux-provider/src/pq.rs
@@ -1,5 +1,6 @@
 use core::convert::TryFrom;
-use libcrux_ml_kem::mlkem768;
+
+use libcrux::algorithms::mlkem;
 
 use alloc::{boxed::Box, vec, vec::Vec};
 use rand_core::TryRngCore;
@@ -19,9 +20,9 @@ impl SupportedKxGroup for X25519MlKem768 {
     fn start(&self) -> Result<Box<dyn ActiveKeyExchange>, Error> {
         let x25519 = crate::kx::X25519.start()?;
 
-        let mut rand = [0u8; libcrux_ml_kem::KEY_GENERATION_SEED_SIZE];
+        let mut rand = [0u8; mlkem::KEY_GENERATION_SEED_SIZE];
         rand_core::OsRng.try_fill_bytes(&mut rand).unwrap();
-        let ml_kem = mlkem768::generate_key_pair(rand);
+        let ml_kem = mlkem::mlkem768::generate_key_pair(rand);
 
         let mut combined_pub_key = Vec::with_capacity(COMBINED_PUBKEY_LEN);
         combined_pub_key.extend_from_slice(ml_kem.public_key().as_slice());
@@ -41,12 +42,12 @@ impl SupportedKxGroup for X25519MlKem768 {
 
         let x25519 = crate::kx::X25519.start_and_complete(share.x25519)?;
 
-        let mut rand = [0u8; libcrux_ml_kem::ENCAPS_SEED_SIZE];
+        let mut rand = [0u8; mlkem::ENCAPS_SEED_SIZE];
         rand_core::OsRng.try_fill_bytes(&mut rand).unwrap();
 
         let pk =
-            mlkem768::MlKem768PublicKey::try_from(share.ml_kem).map_err(|_| INVALID_KEY_SHARE)?;
-        let (ml_kem_share, ml_kem_secret) = mlkem768::encapsulate(&pk, rand);
+            mlkem::mlkem768::MlKem768PublicKey::try_from(share.ml_kem).map_err(|_| INVALID_KEY_SHARE)?;
+        let (ml_kem_share, ml_kem_secret) = mlkem::mlkem768::encapsulate(&pk, rand);
 
         let combined_secret = CombinedSecret::combine(x25519.secret, ml_kem_secret);
         let combined_share = CombinedShare::combine(&x25519.pub_key, ml_kem_share);
@@ -73,7 +74,7 @@ impl SupportedKxGroup for X25519MlKem768 {
 
 struct Active {
     x25519: Box<dyn ActiveKeyExchange>,
-    key_pair: Box<mlkem768::MlKem768KeyPair>,
+    key_pair: Box<mlkem::mlkem768::MlKem768KeyPair>,
     combined_pub_key: Vec<u8>,
 }
 
@@ -86,7 +87,7 @@ impl ActiveKeyExchange for Active {
         let combined = CombinedSecret::combine(
             self.x25519
                 .complete(ciphertext.x25519)?,
-            mlkem768::decapsulate(
+            mlkem::mlkem768::decapsulate(
                 self.key_pair.private_key(),
                 &ciphertext
                     .ml_kem
@@ -145,7 +146,7 @@ impl<'a> ReceivedCiphertext<'a> {
 struct CombinedSecret([u8; COMBINED_SHARED_SECRET_LEN]);
 
 impl CombinedSecret {
-    fn combine(x25519: SharedSecret, ml_kem: [u8; libcrux_ml_kem::SHARED_SECRET_SIZE]) -> Self {
+    fn combine(x25519: SharedSecret, ml_kem: [u8; mlkem::SHARED_SECRET_SIZE]) -> Self {
         let mut out = CombinedSecret([0u8; COMBINED_SHARED_SECRET_LEN]);
         out.0[..MLKEM768_SECRET_LEN].copy_from_slice(ml_kem.as_slice());
         out.0[MLKEM768_SECRET_LEN..].copy_from_slice(x25519.secret_bytes());
@@ -156,7 +157,7 @@ impl CombinedSecret {
 struct CombinedShare(Vec<u8>);
 
 impl CombinedShare {
-    fn combine(x25519: &[u8], ml_kem: mlkem768::MlKem768Ciphertext) -> Self {
+    fn combine(x25519: &[u8], ml_kem: mlkem::mlkem768::MlKem768Ciphertext) -> Self {
         let mut out = CombinedShare(vec![0u8; COMBINED_CIPHERTEXT_LEN]);
         out.0[..MLKEM768_CIPHERTEXT_LEN].copy_from_slice(ml_kem.as_ref());
         out.0[MLKEM768_CIPHERTEXT_LEN..].copy_from_slice(x25519);
@@ -164,7 +165,7 @@ impl CombinedShare {
     }
 }
 
-const NAMED_GROUP: NamedGroup = NamedGroup::Unknown(0x11ec);
+const NAMED_GROUP: NamedGroup = NamedGroup::X25519MLKEM768;
 
 const INVALID_KEY_SHARE: Error = Error::PeerMisbehaved(PeerMisbehaved::InvalidKeyShare);
 

--- a/libcrux-provider/src/sign.rs
+++ b/libcrux-provider/src/sign.rs
@@ -1,6 +1,7 @@
+use std::vec;
+
 use alloc::boxed::Box;
 use alloc::string::String;
-use alloc::sync::Arc;
 use alloc::vec::Vec;
 
 use der::oid::Arc as OidArc;
@@ -14,13 +15,9 @@ use rustls::{SignatureAlgorithm, SignatureScheme};
 
 use der::{asn1::UintRef, Encode};
 
-use libcrux::signature;
-
-#[derive(Clone, Debug)]
-pub struct EcdsaSigningKeyP256 {
-    key: Arc<Vec<u8>>,
-    scheme: SignatureScheme,
-}
+use libcrux::algorithms::rsapss;
+use libcrux::algorithms::ecdsa;
+use libcrux::algorithms::ed25519;
 
 #[derive(Clone, Debug, Copy)]
 pub enum EcdsaSignatureScheme {
@@ -29,15 +26,13 @@ pub enum EcdsaSignatureScheme {
     ECDSA_NISTP256_SHA256,
 }
 
-#[derive(Clone, Debug)]
 pub enum LibcruxSigningKey {
     RsaPss {
         n: Vec<u8>,
         d: Vec<u8>,
-        key_size: signature::rsa_pss::RsaPssKeySize,
-        hash_algo: signature::DigestAlgorithm,
+        hash_algo: rsapss::DigestAlgorithm,
     },
-    Ecdsa(Vec<u8>, EcdsaSignatureScheme),
+    Ecdsa(ecdsa::p256::PrivateKey, EcdsaSignatureScheme),
     Ed25519([u8; 32]),
 }
 
@@ -71,20 +66,21 @@ impl TryFrom<PrivateKeyDer<'_>> for LibcruxSigningKey {
                             ObjectIdentifier::from_bytes(parameter.value()).unwrap();
                         let parameter_oid_arcs: Vec<OidArc> = parameter_oid.arcs().collect();
 
-                        let scheme = match parameter_oid_arcs.as_slice() {
+                        let (key, scheme) = match parameter_oid_arcs.as_slice() {
                             [1, 2, 840, 10045, 3, 1, 7] => {
-                                EcdsaSignatureScheme::ECDSA_NISTP256_SHA256
+                                let key = private_key_info.private_key;
+                                let key: ecdsa::p256::PrivateKey = EcPrivateKey::try_from(key)
+                                    .map_err(|_| pkcs8::Error::KeyMalformed)?
+                                    .private_key
+                                    .try_into()
+                                    .map_err(|_| pkcs8::Error::KeyMalformed)?;
+
+                                (key, EcdsaSignatureScheme::ECDSA_NISTP256_SHA256)
                             }
                             // [1, 3, 132, 0, 34] => EcdsaSignatureScheme::ECDSA_NISTP384_SHA384,
                             // [1, 3, 132, 0, 35] => EcdsaSignatureScheme::ECDSA_NISTP521_SHA512,
                             _ => return Err(pkcs8::Error::KeyMalformed),
                         };
-
-                        let key = private_key_info.private_key;
-                        let key = EcPrivateKey::try_from(key)
-                            .map_err(|_| pkcs8::Error::KeyMalformed)?
-                            .private_key
-                            .to_vec();
 
                         Ok(Self::Ecdsa(key, scheme))
                     }
@@ -103,15 +99,6 @@ impl TryFrom<PrivateKeyDer<'_>> for LibcruxSigningKey {
                         let d = rsa_priv_key.private_exponent.as_bytes();
                         let d = trim_leading_zeroes(d).to_vec();
 
-                        let key_size = match n.len() {
-                            256 => signature::rsa_pss::RsaPssKeySize::N2048,
-                            384 => signature::rsa_pss::RsaPssKeySize::N3072,
-                            512 => signature::rsa_pss::RsaPssKeySize::N4096,
-                            768 => signature::rsa_pss::RsaPssKeySize::N6144,
-                            1024 => signature::rsa_pss::RsaPssKeySize::N8192,
-                            _ => return Err(pkcs8::Error::KeyMalformed),
-                        };
-
                         // let pub_key =
                         //     signature::rsa_pss::RsaPssPublicKey::new(key_size, &n).unwrap();
                         // let priv_key = signature::rsa_pss::RsaPssPrivateKey::new(&pub_key, &d);
@@ -119,8 +106,7 @@ impl TryFrom<PrivateKeyDer<'_>> for LibcruxSigningKey {
                         Ok(Self::RsaPss {
                             n,
                             d,
-                            key_size,
-                            hash_algo: signature::DigestAlgorithm::Sha256,
+                            hash_algo: rsapss::DigestAlgorithm::Sha2_256,
                         })
                     }
                     _ => Err(pkcs8::Error::KeyMalformed),
@@ -141,6 +127,45 @@ fn trim_leading_zeroes(mut buf: &[u8]) -> &[u8] {
     }
     buf
 }
+
+impl core::fmt::Debug for LibcruxSigningKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            LibcruxSigningKey::RsaPss { n, d: _, hash_algo } => {
+                f.debug_struct("RsaPss")
+                    .field("modulus_len", &n.len())
+                    .field("private_exponent", &"<redacted>")
+                    .field("hash_algo", hash_algo)
+                    .finish()
+            }
+            LibcruxSigningKey::Ecdsa(_, scheme) => {
+                f.debug_struct("Ecdsa")
+                    .field("private_key", &"<redacted>")
+                    .field("scheme", scheme)
+                    .finish()
+            }
+            LibcruxSigningKey::Ed25519(_) => {
+                f.debug_struct("Ed25519")
+                    .field("private_key", &"<redacted>")
+                    .finish()
+            }
+        }
+    }
+}
+
+impl Clone for LibcruxSigningKey {
+    fn clone(&self) -> Self {
+        match self {
+            LibcruxSigningKey::Ecdsa(key, scheme) => {
+                let key_slice: &[u8; 32] = key.as_ref();
+                let key = ecdsa::p256::PrivateKey::try_from(key_slice).unwrap();
+                LibcruxSigningKey::Ecdsa(key, *scheme)
+            }
+            LibcruxSigningKey::Ed25519(key) => LibcruxSigningKey::Ed25519(*key),
+            LibcruxSigningKey::RsaPss { n, d, hash_algo } => LibcruxSigningKey::RsaPss { n: n.clone(), d: d.clone(), hash_algo: *hash_algo },
+        }
+    }
+}
 impl SigningKey for LibcruxSigningKey {
     fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
         if offered.contains(&self.scheme()) {
@@ -159,89 +184,50 @@ impl SigningKey for LibcruxSigningKey {
     }
 }
 
-impl SigningKey for EcdsaSigningKeyP256 {
-    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
-        if offered.contains(&self.scheme) {
-            Some(Box::new(self.clone()))
-        } else {
-            None
-        }
-    }
-
-    fn algorithm(&self) -> SignatureAlgorithm {
-        SignatureAlgorithm::ECDSA
-    }
-}
-
-impl Signer for EcdsaSigningKeyP256 {
-    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
-        let mut rng = rand_core::OsRng;
-        signature::sign(
-            signature::Algorithm::EcDsaP256(signature::DigestAlgorithm::Sha256),
-            message,
-            &self.key,
-            &mut rng.unwrap_mut(),
-        )
-        .map_err(|_| rustls::Error::General("signing failed".into()))
-        .map(|sig| match sig {
-            signature::Signature::EcDsaP256(sig) => der_encode_ecdsa_signature(&sig).unwrap(),
-            _ => unreachable!(),
-        })
-    }
-
-    fn scheme(&self) -> SignatureScheme {
-        self.scheme
-    }
-}
-
 impl Signer for LibcruxSigningKey {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
         match self {
             LibcruxSigningKey::RsaPss {
                 n,
                 d,
-                key_size,
                 hash_algo,
             } => {
+                let mut sig = vec![0u8; n.len()];
                 let mut salt = [0u8; 32];
                 rand_core::OsRng.try_fill_bytes(&mut salt).unwrap();
-                let pub_key =
-                    signature::rsa_pss::RsaPssPublicKey::new(*key_size, n).map_err(|_| {
-                        rustls::Error::General(String::from("error building public key"))
-                    })?;
+                let n = n.as_slice();
+                let d = d.as_slice();
+
                 let priv_key =
-                    signature::rsa_pss::RsaPssPrivateKey::new(&pub_key, d).map_err(|_| {
+                    rsapss::VarLenPrivateKey::from_components(n, d).map_err(|_| {
                         rustls::Error::General(String::from("error building private key"))
                     })?;
-                let sig = priv_key
-                    .sign(*hash_algo, &salt, message)
+                rsapss::sign_varlen(*hash_algo, &priv_key, message, &salt, sig.as_mut_slice())
                     .map_err(|_| rustls::Error::General(String::from("error signing")))?;
 
-                Ok(sig.as_bytes().to_vec())
+                Ok(sig)
             }
 
             LibcruxSigningKey::Ecdsa(private_key, scheme) => {
-                let alg = match scheme {
+                match scheme {
                     EcdsaSignatureScheme::ECDSA_NISTP256_SHA256 => {
-                        signature::Algorithm::EcDsaP256(signature::DigestAlgorithm::Sha256)
-                    } // EcdsaSignatureScheme::ECDSA_NISTP384_SHA384 => todo!(),
-                      // EcdsaSignatureScheme::ECDSA_NISTP521_SHA512 => todo!(),
-                };
-                let sig = signature::sign(alg, message, private_key, &mut rand_core::OsRng.unwrap_mut())
-                    .map_err(|_| rustls::Error::General(String::from("signing error")))?;
-
-                match sig {
-                    signature::Signature::EcDsaP256(sig) => der_encode_ecdsa_signature(&sig)
-                        .map_err(|_| {
+                        let alg = ecdsa::DigestAlgorithm::Sha256;
+                        let nonce = ecdsa::p256::Nonce::random(&mut rand_core::OsRng.unwrap_mut())
+                            .map_err(|_| rustls::Error::General(String::from("signing error")))?;
+                        let sig = ecdsa::p256::sign(alg, message, private_key, &nonce)
+                            .map_err(|_| rustls::Error::General(String::from("signing error")))?;
+                        der_encode_ecdsa_signature(&sig).map_err(|_| {
                             rustls::Error::General(String::from(
                                 "error der encoding ecdsa signature",
                             ))
-                        }),
-                    _ => unreachable!(),
+                        })
+                    }
+                    // EcdsaSignatureScheme::ECDSA_NISTP384_SHA384 => todo!(),
+                    // EcdsaSignatureScheme::ECDSA_NISTP521_SHA512 => todo!(),
                 }
             }
 
-            LibcruxSigningKey::Ed25519(sk) => libcrux_ed25519::sign(message, sk)
+            LibcruxSigningKey::Ed25519(sk) => ed25519::sign(message, sk)
                 .map_err(|_| rustls::Error::General(String::from("signing error")))
                 .map(|sig| sig.to_vec()),
         }
@@ -250,15 +236,15 @@ impl Signer for LibcruxSigningKey {
     fn scheme(&self) -> SignatureScheme {
         match self {
             LibcruxSigningKey::RsaPss {
-                hash_algo: signature::DigestAlgorithm::Sha256,
+                hash_algo: rsapss::DigestAlgorithm::Sha2_256,
                 ..
             } => SignatureScheme::RSA_PSS_SHA256,
             LibcruxSigningKey::RsaPss {
-                hash_algo: signature::DigestAlgorithm::Sha384,
+                hash_algo: rsapss::DigestAlgorithm::Sha2_384,
                 ..
             } => SignatureScheme::RSA_PSS_SHA384,
             LibcruxSigningKey::RsaPss {
-                hash_algo: signature::DigestAlgorithm::Sha512,
+                hash_algo: rsapss::DigestAlgorithm::Sha2_512,
                 ..
             } => SignatureScheme::RSA_PSS_SHA512,
             LibcruxSigningKey::Ecdsa(_, EcdsaSignatureScheme::ECDSA_NISTP256_SHA256) => {
@@ -278,7 +264,7 @@ impl Signer for LibcruxSigningKey {
 // copied from ecdsa crate, where it wasn't public
 /// Create an ASN.1 DER encoded signature from big endian `r` and `s` scalar
 /// components.
-fn der_encode_ecdsa_signature(sig: &signature::EcDsaP256Signature) -> der::Result<Vec<u8>> {
+fn der_encode_ecdsa_signature(sig: &ecdsa::p256::Signature) -> der::Result<Vec<u8>> {
     let (r, s) = sig.as_bytes();
     let r = UintRef::new(r)?;
     let s = UintRef::new(s)?;

--- a/libcrux-provider/src/verify.rs
+++ b/libcrux-provider/src/verify.rs
@@ -1,12 +1,12 @@
 use der::Reader;
-use libcrux::signature::{
-    rsa_pss::{RsaPssPublicKey, RsaPssSignature},
-    verify, DigestAlgorithm, EcDsaP256Signature, Ed25519Signature, Signature,
-};
 use rustls::crypto::WebPkiSupportedAlgorithms;
 use rustls::pki_types::{alg_id, AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
 use rustls::SignatureScheme;
 use webpki::{aws_lc_rs::RSA_PKCS1_2048_8192_SHA256 as AWS_LC_RSA_PKCS1_SHA256};
+
+use libcrux::algorithms::ecdsa;
+use libcrux::algorithms::ed25519;
+use libcrux::algorithms::rsapss;
 
 pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
@@ -31,21 +31,21 @@ pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
 };
 
 static RSA_PSS_SHA256: &dyn SignatureVerificationAlgorithm =
-    &RsaPssVerify(DigestAlgorithm::Sha256, 0x20);
+    &RsaPssVerify(rsapss::DigestAlgorithm::Sha2_256, 0x20);
 
 static RSA_PSS_SHA384: &dyn SignatureVerificationAlgorithm =
-    &RsaPssVerify(DigestAlgorithm::Sha384, 0x20);
+    &RsaPssVerify(rsapss::DigestAlgorithm::Sha2_384, 0x20);
 
 static RSA_PSS_SHA512: &dyn SignatureVerificationAlgorithm =
-    &RsaPssVerify(DigestAlgorithm::Sha512, 0x20);
+    &RsaPssVerify(rsapss::DigestAlgorithm::Sha2_512, 0x20);
 
 static ED25519: &dyn SignatureVerificationAlgorithm = &Ed25519Verify;
 
 static ECDSA_P256_SHA256: &dyn SignatureVerificationAlgorithm =
-    &EcdsaP256Verify(DigestAlgorithm::Sha256);
+    &EcdsaP256Verify(ecdsa::DigestAlgorithm::Sha256);
 
 #[derive(Debug, Clone, Copy)]
-struct EcdsaP256Verify(DigestAlgorithm);
+struct EcdsaP256Verify(ecdsa::DigestAlgorithm);
 
 impl SignatureVerificationAlgorithm for EcdsaP256Verify {
     fn verify_signature(
@@ -68,12 +68,14 @@ impl SignatureVerificationAlgorithm for EcdsaP256Verify {
             .as_bytes()
             .try_into()
             .map_err(|_| InvalidSignature)?;
-        let signature = Signature::EcDsaP256(EcDsaP256Signature::from_raw(
+        let signature = ecdsa::p256::Signature::from_raw(
             r,
             s,
-            libcrux::signature::Algorithm::EcDsaP256(self.0),
-        ));
-        verify(message, &signature, public_key).map_err(|_| InvalidSignature)
+        );
+        let public_key = ecdsa::p256::PublicKey::try_from(public_key)
+            .map_err(|_| InvalidSignature)?;
+        let alg = ecdsa::DigestAlgorithm::Sha256;
+        ecdsa::p256::verify(alg, message, &signature, &public_key).map_err(|_| InvalidSignature)
     }
 
     fn public_key_alg_id(&self) -> AlgorithmIdentifier {
@@ -82,9 +84,10 @@ impl SignatureVerificationAlgorithm for EcdsaP256Verify {
 
     fn signature_alg_id(&self) -> AlgorithmIdentifier {
         match self.0 {
-            DigestAlgorithm::Sha256 => alg_id::ECDSA_SHA256,
-            DigestAlgorithm::Sha384 => alg_id::ECDSA_SHA384,
-            DigestAlgorithm::Sha512 => alg_id::ECDSA_SHA512,
+            ecdsa::DigestAlgorithm::Sha224 => unreachable!(),
+            ecdsa::DigestAlgorithm::Sha256 => alg_id::ECDSA_SHA256,
+            ecdsa::DigestAlgorithm::Sha384 => alg_id::ECDSA_SHA384,
+            ecdsa::DigestAlgorithm::Sha512 => alg_id::ECDSA_SHA512,
         }
     }
 }
@@ -99,10 +102,9 @@ impl SignatureVerificationAlgorithm for Ed25519Verify {
         message: &[u8],
         signature: &[u8],
     ) -> Result<(), InvalidSignature> {
-        let signature = Signature::Ed25519(
-            Ed25519Signature::from_slice(signature).map_err(|_| InvalidSignature)?,
-        );
-        verify(message, &signature, public_key).map_err(|_| InvalidSignature)
+        let public_key: [u8; 32] = public_key.try_into().map_err(|_| InvalidSignature)?;
+        let signature: [u8; 64] = signature.try_into().map_err(|_| InvalidSignature)?;
+        ed25519::verify(message, &public_key, &signature).map_err(|_| InvalidSignature)
     }
 
     fn public_key_alg_id(&self) -> AlgorithmIdentifier {
@@ -115,7 +117,7 @@ impl SignatureVerificationAlgorithm for Ed25519Verify {
 }
 
 #[derive(Debug, Clone, Copy)]
-struct RsaPssVerify(DigestAlgorithm, usize);
+struct RsaPssVerify(rsapss::DigestAlgorithm, usize);
 
 impl SignatureVerificationAlgorithm for RsaPssVerify {
     fn public_key_alg_id(&self) -> AlgorithmIdentifier {
@@ -124,9 +126,9 @@ impl SignatureVerificationAlgorithm for RsaPssVerify {
 
     fn signature_alg_id(&self) -> AlgorithmIdentifier {
         match self.0 {
-            libcrux::signature::DigestAlgorithm::Sha256 => alg_id::RSA_PSS_SHA256,
-            libcrux::signature::DigestAlgorithm::Sha384 => alg_id::RSA_PSS_SHA384,
-            libcrux::signature::DigestAlgorithm::Sha512 => alg_id::RSA_PSS_SHA512,
+            rsapss::DigestAlgorithm::Sha2_256 => alg_id::RSA_PSS_SHA256,
+            rsapss::DigestAlgorithm::Sha2_384 => alg_id::RSA_PSS_SHA384,
+            rsapss::DigestAlgorithm::Sha2_512 => alg_id::RSA_PSS_SHA512,
         }
     }
 
@@ -137,16 +139,15 @@ impl SignatureVerificationAlgorithm for RsaPssVerify {
         signature: &[u8],
     ) -> Result<(), InvalidSignature> {
         let Self(digest_algo, salt_len) = *self;
+        let salt_len: u32 = salt_len.try_into().map_err(|_| InvalidSignature)?;
         let public_key = decode_spki_spk(public_key)?;
-        let signature = RsaPssSignature::from(signature);
 
-        public_key
-            .verify(digest_algo, &signature, message, salt_len)
+        rsapss::verify(digest_algo, &public_key, message, salt_len, signature)
             .map_err(|_| InvalidSignature)
     }
 }
 
-fn decode_spki_spk(spki_spk: &[u8]) -> Result<RsaPssPublicKey, InvalidSignature> {
+fn decode_spki_spk(spki_spk: &[u8]) -> Result<rsapss::VarLenPublicKey<'_>, InvalidSignature> {
     // public_key: unfortunately this is not a whole SPKI, but just the key material.
     // decode the two integers manually.
     let mut reader = der::SliceReader::new(spki_spk).map_err(|_| InvalidSignature)?;
@@ -162,16 +163,7 @@ fn decode_spki_spk(spki_spk: &[u8]) -> Result<RsaPssPublicKey, InvalidSignature>
         return Err(InvalidSignature);
     }
 
-    let key_size = match n.len() {
-        256 => libcrux::signature::rsa_pss::RsaPssKeySize::N2048,
-        384 => libcrux::signature::rsa_pss::RsaPssKeySize::N3072,
-        512 => libcrux::signature::rsa_pss::RsaPssKeySize::N4096,
-        768 => libcrux::signature::rsa_pss::RsaPssKeySize::N6144,
-        1024 => libcrux::signature::rsa_pss::RsaPssKeySize::N8192,
-        _ => return Err(InvalidSignature),
-    };
-
-    libcrux::signature::rsa_pss::RsaPssPublicKey::new(key_size, n).map_err(|_| InvalidSignature)
+    rsapss::VarLenPublicKey::try_from(n).map_err(|_| InvalidSignature)
 }
 
 struct DerEcdsaSignature {


### PR DESCRIPTION
Hello everyone,

addressing issue #7, this PR uses the official libcrux crate and its reexports of libcrux algorithms.
Therefore, the new package relies mostly on libcrux with some exceptions:

libcrux_ecdh is not yet part of libcrux and must be exported separately
libcrux_traits and hpke-rs-crypto are required for the aead and hpke traits
hpke-rs-rust-crypto is required for the rust crypto hpke backend of hpke
hpke-rs with hazmat is required to be able to transform a libcrux HpkePrivateKey back to bytes in hpke.rs, line 319.

Additionally, NamedGroup::Unknown(0x11ec) is replaced with NamedGroup::X25519MLKEM768 everywhere.

I tried to use predefined structs such as the typed byte slices of private keys whenever it was applicable. 

All modules except hpke have been tested via browser connections. For hpke the rust test runs through.

I am happy to discuss the changes!