### PR TITLE
Added: TLS1.3 HKDF from Libcrux HKDF

### DIFF
--- a/libcrux-provider/examples/client.rs
+++ b/libcrux-provider/examples/client.rs
@@ -5,11 +5,8 @@ use std::sync::Arc;
 fn main() {
     env_logger::init();
 
-    let root_store = rustls::RootCertStore::from_iter(
-        webpki_roots::TLS_SERVER_ROOTS
-            .iter()
-            .cloned(),
-    );
+    let root_store =
+        rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
     let config =
         rustls::ClientConfig::builder_with_provider(rustls_libcrux_provider::provider().into())
@@ -18,9 +15,7 @@ fn main() {
             .with_root_certificates(root_store)
             .with_no_client_auth();
 
-    let server_name = "raw.githubusercontent.com"
-        .try_into()
-        .unwrap();
+    let server_name = "raw.githubusercontent.com".try_into().unwrap();
     let mut conn = rustls::ClientConnection::new(Arc::new(config), server_name).unwrap();
     let mut sock = TcpStream::connect("raw.githubusercontent.com:443").unwrap();
     let mut tls = rustls::Stream::new(&mut conn, &mut sock);
@@ -35,10 +30,7 @@ fn main() {
         .as_bytes(),
     )
     .unwrap();
-    let ciphersuite = tls
-        .conn
-        .negotiated_cipher_suite()
-        .unwrap();
+    let ciphersuite = tls.conn.negotiated_cipher_suite().unwrap();
     writeln!(
         &mut std::io::stderr(),
         "Current ciphersuite: {:?}",

--- a/libcrux-provider/src/aead.rs
+++ b/libcrux-provider/src/aead.rs
@@ -12,10 +12,8 @@ use rustls::{
     ConnectionTrafficSecrets, ContentType, ProtocolVersion,
 };
 
-use libcrux::{algorithms::aes_gcm::Aead, primitives::aead};
 use libcrux::algorithms::chacha20poly1305;
-
-
+use libcrux::{algorithms::aes_gcm::Aead, primitives::aead};
 
 pub enum LibcruxAeadKey {
     Chacha20Poly1305([u8; chacha20poly1305::KEY_LEN]),
@@ -105,7 +103,10 @@ impl MessageEncrypter for Tls13Cipher {
         let mut ciphertext = vec![0u8; plaintext.len()];
 
         let key = match &self.0 {
-            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::EncryptError)?,
+            LibcruxAeadKey::Chacha20Poly1305(key) => {
+                aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key)
+                    .map_err(|_| rustls::Error::EncryptError)?
+            }
         };
 
         let mut tag = vec![0u8; key.algo().tag_len()];
@@ -145,7 +146,10 @@ impl MessageDecrypter for Tls13Cipher {
         seq: u64,
     ) -> Result<InboundPlainMessage<'a>, rustls::Error> {
         let key = match &self.0 {
-            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::DecryptError)?,
+            LibcruxAeadKey::Chacha20Poly1305(key) => {
+                aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key)
+                    .map_err(|_| rustls::Error::DecryptError)?
+            }
         };
 
         let payload_and_tag = &mut m.payload;
@@ -170,8 +174,7 @@ impl MessageDecrypter for Tls13Cipher {
         key.decrypt(&mut plaintext, nonce, &aad, payload, tag)
             .map_err(|_| rustls::Error::DecryptError)?;
 
-        m.payload
-            .truncate(m.payload.len() - tag_len);
+        m.payload.truncate(m.payload.len() - tag_len);
 
         m.payload.copy_from_slice(&plaintext);
 
@@ -196,9 +199,12 @@ impl MessageEncrypter for Tls12Cipher {
         let nonce = Nonce::new(&self.1, seq);
         let aad = make_tls12_aad(seq, m.typ, m.version, m.payload.len());
         let mut ciphertext = vec![0u8; plaintext.len()];
-        
+
         let key = match &self.0 {
-            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::EncryptError)?,
+            LibcruxAeadKey::Chacha20Poly1305(key) => {
+                aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key)
+                    .map_err(|_| rustls::Error::EncryptError)?
+            }
         };
 
         let mut tag = vec![0u8; key.algo().tag_len()];
@@ -215,11 +221,7 @@ impl MessageEncrypter for Tls12Cipher {
         let mut payload = PrefixedPayload::with_capacity(total_len);
         payload.extend_from_slice(&ciphertext);
 
-        Ok(OutboundOpaqueMessage::new(
-            m.typ,
-            m.version,
-            payload,
-        ))
+        Ok(OutboundOpaqueMessage::new(m.typ, m.version, payload))
     }
 
     fn encrypted_payload_len(&self, payload_len: usize) -> usize {
@@ -234,7 +236,10 @@ impl MessageDecrypter for Tls12Cipher {
         seq: u64,
     ) -> Result<InboundPlainMessage<'a>, rustls::Error> {
         let key = match &self.0 {
-            LibcruxAeadKey::Chacha20Poly1305(key) => aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key).map_err(|_| rustls::Error::DecryptError)?,
+            LibcruxAeadKey::Chacha20Poly1305(key) => {
+                aead::KeyRef::new_for_algo(aead::Aead::ChaCha20Poly1305, key)
+                    .map_err(|_| rustls::Error::DecryptError)?
+            }
         };
 
         let payload_and_tag = &mut m.payload;
@@ -263,8 +268,7 @@ impl MessageDecrypter for Tls12Cipher {
         key.decrypt(&mut plaintext, nonce, &aad, payload, tag)
             .map_err(|_| rustls::Error::DecryptError)?;
 
-        m.payload
-            .truncate(m.payload.len() - tag_len);
+        m.payload.truncate(m.payload.len() - tag_len);
 
         m.payload.copy_from_slice(&plaintext);
 

--- a/libcrux-provider/src/hkdf.rs
+++ b/libcrux-provider/src/hkdf.rs
@@ -1,0 +1,72 @@
+use alloc::boxed::Box;
+
+use libcrux::algorithms::{hkdf, hmac};
+use rustls::crypto;
+
+pub struct Sha256HKDF;
+
+const SHA2_256_LEN: usize = 32;
+
+impl crypto::tls13::Hkdf for Sha256HKDF {
+    fn extract_from_zero_ikm(&self, salt: Option<&[u8]>) -> Box<dyn crypto::tls13::HkdfExpander> {
+        let mut prk = [0u8; SHA2_256_LEN];
+        let ikm = [0u8; SHA2_256_LEN];
+        let salt = salt.unwrap_or(&[0u8; SHA2_256_LEN]);
+
+        hkdf::sha2_256::extract(&mut prk, salt, &ikm).unwrap();
+
+        Box::new(Sha256HKDFKey(prk))
+    }
+
+    fn extract_from_secret(
+        &self,
+        salt: Option<&[u8]>,
+        secret: &[u8],
+    ) -> Box<dyn crypto::tls13::HkdfExpander> {
+        let mut prk = [0u8; SHA2_256_LEN];
+        let salt = salt.unwrap_or(&[0u8; SHA2_256_LEN]);
+
+        hkdf::sha2_256::extract(&mut prk, salt, secret).unwrap();
+
+        Box::new(Sha256HKDFKey(prk))
+    }
+
+    fn expander_for_okm(
+        &self,
+        okm: &crypto::tls13::OkmBlock,
+    ) -> Box<dyn crypto::tls13::HkdfExpander> {
+        let key: [u8; 32] = okm.as_ref().try_into().unwrap();
+        Box::new(Sha256HKDFKey(key))
+    }
+
+    fn hmac_sign(&self, key: &crypto::tls13::OkmBlock, message: &[u8]) -> crypto::hmac::Tag {
+        let result = hmac::hmac(hmac::Algorithm::Sha256, key.as_ref(), message, None);
+        crypto::hmac::Tag::new(&result[..])
+    }
+}
+
+struct Sha256HKDFKey([u8; SHA2_256_LEN]);
+
+impl crypto::tls13::HkdfExpander for Sha256HKDFKey {
+    fn expand_slice(
+        &self,
+        info: &[&[u8]],
+        output: &mut [u8],
+    ) -> Result<(), crypto::tls13::OutputLengthError> {
+        hkdf::sha2_256::expand(output, &self.0, &info.concat())
+            .map_err(|_| crypto::tls13::OutputLengthError)
+    }
+
+    fn expand_block(&self, info: &[&[u8]]) -> crypto::tls13::OkmBlock {
+        let mut okm = [0u8; SHA2_256_LEN];
+        // In this setting, okm and prk are guaranteed to be in bounds, so only info can fail
+        hkdf::sha2_256::expand(&mut okm, &self.0, &info.concat()).expect("info too long");
+
+        crypto::tls13::OkmBlock::new(&okm)
+    }
+
+    fn hash_len(&self) -> usize {
+        SHA2_256_LEN
+    }
+}
+

--- a/libcrux-provider/src/hmac.rs
+++ b/libcrux-provider/src/hmac.rs
@@ -1,8 +1,7 @@
 use alloc::boxed::Box;
 
+use libcrux::algorithms::{hmac, sha2};
 use rustls::crypto;
-use libcrux::algorithms::sha2 as sha2;
-use libcrux::algorithms::hmac as hmac;
 
 pub struct Sha256Hmac;
 

--- a/libcrux-provider/src/hpke.rs
+++ b/libcrux-provider/src/hpke.rs
@@ -27,7 +27,7 @@ pub static ALL_SUPPORTED_SUITES: &[&dyn Hpke] = &[
     DHKEM_X25519_HKDF_SHA256_CHACHA20_POLY1305,
 ];
 
-pub static DHKEM_P256_HKDF_SHA256_AES_128: &LibcruxHpkeConfig = &LibcruxHpkeConfig{
+pub static DHKEM_P256_HKDF_SHA256_AES_128: &LibcruxHpkeConfig = &LibcruxHpkeConfig {
     mode: hpke::Mode::Base,
     kem: hpke::hpke_types::KemAlgorithm::DhKemP256,
     kdf: hpke::hpke_types::KdfAlgorithm::HkdfSha256,
@@ -72,7 +72,8 @@ struct LibcruxHpkeSealer {
 
 impl HpkeSealer for LibcruxHpkeSealer {
     fn seal(&mut self, aad: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, Error> {
-        self.context.seal(aad, plaintext)
+        self.context
+            .seal(aad, plaintext)
             .map_err(|_| Error::General(String::from("hpke seal error")))
     }
 }
@@ -84,7 +85,8 @@ struct LibcruxHpkeOpener {
 
 impl HpkeOpener for LibcruxHpkeOpener {
     fn open(&mut self, aad: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, Error> {
-        self.context.open(aad, ciphertext)
+        self.context
+            .open(aad, ciphertext)
             .map_err(|_| Error::General(String::from("hpke open error")))
     }
 }
@@ -111,12 +113,12 @@ impl Hpke for LibcruxHpkeConfig {
         plaintext: &[u8],
         pub_key: &HpkePublicKey,
     ) -> Result<(EncapsulatedSecret, Vec<u8>), Error> {
-
         let mut config = hpke::Hpke::<HPKEProvider::HpkeLibcrux>::from(self);
 
         let pk_r = hpke::HpkePublicKey::from(pub_key.0.as_slice());
 
-        config.seal(&pk_r, info, aad, plaintext, None, None, None)
+        config
+            .seal(&pk_r, info, aad, plaintext, None, None, None)
             .map_err(|_| Error::General(alloc::string::String::from("hpke seal error")))
             .map(|ctxt| (EncapsulatedSecret(ctxt.0), ctxt.1))
     }
@@ -130,14 +132,13 @@ impl Hpke for LibcruxHpkeConfig {
 
         let pk_r = hpke::HpkePublicKey::from(pub_key.0.as_slice());
 
-        let (kem_ctxt, ctx) = config.setup_sender(&pk_r, info, None, None, None)
+        let (kem_ctxt, ctx) = config
+            .setup_sender(&pk_r, info, None, None, None)
             .map_err(|_| Error::General(alloc::string::String::from("hpke setup sealer error")))?;
 
         Ok((
             EncapsulatedSecret(kem_ctxt),
-            Box::new(LibcruxHpkeSealer {
-                context: ctx,
-            }),
+            Box::new(LibcruxHpkeSealer { context: ctx }),
         ))
     }
 
@@ -153,7 +154,8 @@ impl Hpke for LibcruxHpkeConfig {
 
         let sk_r = hpke::HpkePrivateKey::from(secret_key.secret_bytes());
 
-        config.open(&enc.0, &sk_r, info, aad, ciphertext, None, None, None)
+        config
+            .open(&enc.0, &sk_r, info, aad, ciphertext, None, None, None)
             .map_err(|_| Error::General(alloc::string::String::from("hpke open error")))
     }
 
@@ -167,22 +169,26 @@ impl Hpke for LibcruxHpkeConfig {
 
         let sk_r = hpke::HpkePrivateKey::from(secret_key.secret_bytes());
 
-        
-        let ctx = config.setup_receiver(&enc.0, &sk_r, info, None, None, None)
+        let ctx = config
+            .setup_receiver(&enc.0, &sk_r, info, None, None, None)
             .map_err(|_| Error::General(alloc::string::String::from("hpke setup opener error")))?;
 
-        Ok(Box::new(LibcruxHpkeOpener {
-            context: ctx,
-        }))
+        Ok(Box::new(LibcruxHpkeOpener { context: ctx }))
     }
 
     fn generate_key_pair(&self) -> Result<(HpkePublicKey, HpkePrivateKey), Error> {
         let mut config = hpke::Hpke::<HPKEProvider::HpkeLibcrux>::from(self);
 
-        config.generate_key_pair()
+        config
+            .generate_key_pair()
             .map_err(|_| Error::General(String::from("hpke kem keygen error")))
             .map(|pair| pair.into_keys())
-            .map(|(sk, pk)| (HpkePublicKey(pk.as_slice().to_vec()), HpkePrivateKey::from(sk.as_slice().to_vec())))
+            .map(|(sk, pk)| {
+                (
+                    HpkePublicKey(pk.as_slice().to_vec()),
+                    HpkePrivateKey::from(sk.as_slice().to_vec()),
+                )
+            })
     }
 
     fn suite(&self) -> HpkeSuite {
@@ -250,9 +256,7 @@ mod tests {
             let ct = sealer.seal(aad, pt).unwrap();
 
             // We should be able to set up an opener.
-            let mut opener = suite
-                .setup_opener(&enc, info, &sk)
-                .unwrap();
+            let mut opener = suite.setup_opener(&enc, info, &sk).unwrap();
             _ = format!("{opener:?}"); // Opener should be Debug.
 
             // Setting up an opener with an invalid private key should fail.
@@ -281,8 +285,6 @@ mod tests {
     #[test]
     fn test_fips() {
         // None of the rust-crypto backed hpke-rs suites should be considered FIPS approved.
-        assert!(ALL_SUPPORTED_SUITES
-            .iter()
-            .all(|suite| !suite.fips()));
+        assert!(ALL_SUPPORTED_SUITES.iter().all(|suite| !suite.fips()));
     }
 }

--- a/libcrux-provider/src/kx.rs
+++ b/libcrux-provider/src/kx.rs
@@ -4,8 +4,8 @@ use alloc::string::String;
 use libcrux::algorithms::curve25519;
 
 use libcrux_traits::ecdh::owned::EcdhOwned;
-use rustls::crypto::{self, SupportedKxGroup as _};
 use rand_core::TryRngCore;
+use rustls::crypto::{self, SupportedKxGroup as _};
 
 use crate::pq::X25519MlKem768;
 
@@ -19,7 +19,9 @@ impl crypto::ActiveKeyExchange for X25519KeyExchange {
         self: Box<X25519KeyExchange>,
         peer: &[u8],
     ) -> Result<crypto::SharedSecret, rustls::Error> {
-        let peer: [u8; 32] = peer.try_into().map_err(|_| rustls::Error::General(String::from("ecdh derive error")))?;
+        let peer: [u8; 32] = peer
+            .try_into()
+            .map_err(|_| rustls::Error::General(String::from("ecdh derive error")))?;
         let shared_secret = curve25519::X25519::derive_ecdh(&peer, &self.priv_key)
             .map_err(|_| rustls::Error::General(String::from("ecdh derive error")))?;
 
@@ -46,8 +48,11 @@ pub struct X25519;
 impl crypto::SupportedKxGroup for X25519 {
     fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
         let mut rand: [u8; 32] = [0u8; 32];
-        rand_core::OsRng.try_fill_bytes(&mut rand).map_err(|_| rustls::Error::FailedToGetRandomBytes)?;
-        let (pub_key, priv_key) = curve25519::X25519::generate_pair(&rand).map_err(|_| rustls::Error::General(String::from("ecdh keygen error")))?;
+        rand_core::OsRng
+            .try_fill_bytes(&mut rand)
+            .map_err(|_| rustls::Error::FailedToGetRandomBytes)?;
+        let (pub_key, priv_key) = curve25519::X25519::generate_pair(&rand)
+            .map_err(|_| rustls::Error::General(String::from("ecdh keygen error")))?;
 
         Ok(Box::new(X25519KeyExchange { pub_key, priv_key }))
     }

--- a/libcrux-provider/src/lib.rs
+++ b/libcrux-provider/src/lib.rs
@@ -11,6 +11,7 @@ use rustls::pki_types::PrivateKeyDer;
 
 mod aead;
 mod hash;
+mod hkdf;
 mod hmac;
 #[cfg(feature = "std")]
 pub mod hpke;
@@ -70,7 +71,7 @@ pub static TLS13_CHACHA20_POLY1305_SHA256: rustls::SupportedCipherSuite =
             hash_provider: &hash::Sha256,
             confidentiality_limit: u64::MAX,
         },
-        hkdf_provider: &rustls::crypto::tls13::HkdfUsingHmac(&hmac::Sha256Hmac),
+        hkdf_provider: &hkdf::Sha256HKDF,
         aead_alg: &aead::Chacha20Poly1305,
         quic: None,
     });

--- a/libcrux-provider/src/pq.rs
+++ b/libcrux-provider/src/pq.rs
@@ -45,8 +45,8 @@ impl SupportedKxGroup for X25519MlKem768 {
         let mut rand = [0u8; mlkem::ENCAPS_SEED_SIZE];
         rand_core::OsRng.try_fill_bytes(&mut rand).unwrap();
 
-        let pk =
-            mlkem::mlkem768::MlKem768PublicKey::try_from(share.ml_kem).map_err(|_| INVALID_KEY_SHARE)?;
+        let pk = mlkem::mlkem768::MlKem768PublicKey::try_from(share.ml_kem)
+            .map_err(|_| INVALID_KEY_SHARE)?;
         let (ml_kem_share, ml_kem_secret) = mlkem::mlkem768::encapsulate(&pk, rand);
 
         let combined_secret = CombinedSecret::combine(x25519.secret, ml_kem_secret);
@@ -85,8 +85,7 @@ impl ActiveKeyExchange for Active {
         };
 
         let combined = CombinedSecret::combine(
-            self.x25519
-                .complete(ciphertext.x25519)?,
+            self.x25519.complete(ciphertext.x25519)?,
             mlkem::mlkem768::decapsulate(
                 self.key_pair.private_key(),
                 &ciphertext

--- a/libcrux-provider/src/sign.rs
+++ b/libcrux-provider/src/sign.rs
@@ -8,16 +8,14 @@ use der::oid::Arc as OidArc;
 use der::{Decode, Tag, Tagged};
 use pkcs8::ObjectIdentifier;
 use rand_core::TryRngCore;
-use sec1::EcPrivateKey;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
+use sec1::EcPrivateKey;
 
 use der::{asn1::UintRef, Encode};
 
-use libcrux::algorithms::rsapss;
-use libcrux::algorithms::ecdsa;
-use libcrux::algorithms::ed25519;
+use libcrux::algorithms::{ecdsa, ed25519, rsapss};
 
 #[derive(Clone, Debug, Copy)]
 pub enum EcdsaSignatureScheme {
@@ -131,24 +129,21 @@ fn trim_leading_zeroes(mut buf: &[u8]) -> &[u8] {
 impl core::fmt::Debug for LibcruxSigningKey {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            LibcruxSigningKey::RsaPss { n, d: _, hash_algo } => {
-                f.debug_struct("RsaPss")
-                    .field("modulus_len", &n.len())
-                    .field("private_exponent", &"<redacted>")
-                    .field("hash_algo", hash_algo)
-                    .finish()
-            }
-            LibcruxSigningKey::Ecdsa(_, scheme) => {
-                f.debug_struct("Ecdsa")
-                    .field("private_key", &"<redacted>")
-                    .field("scheme", scheme)
-                    .finish()
-            }
-            LibcruxSigningKey::Ed25519(_) => {
-                f.debug_struct("Ed25519")
-                    .field("private_key", &"<redacted>")
-                    .finish()
-            }
+            LibcruxSigningKey::RsaPss { n, d: _, hash_algo } => f
+                .debug_struct("RsaPss")
+                .field("modulus_len", &n.len())
+                .field("private_exponent", &"<redacted>")
+                .field("hash_algo", hash_algo)
+                .finish(),
+            LibcruxSigningKey::Ecdsa(_, scheme) => f
+                .debug_struct("Ecdsa")
+                .field("private_key", &"<redacted>")
+                .field("scheme", scheme)
+                .finish(),
+            LibcruxSigningKey::Ed25519(_) => f
+                .debug_struct("Ed25519")
+                .field("private_key", &"<redacted>")
+                .finish(),
         }
     }
 }
@@ -162,7 +157,11 @@ impl Clone for LibcruxSigningKey {
                 LibcruxSigningKey::Ecdsa(key, *scheme)
             }
             LibcruxSigningKey::Ed25519(key) => LibcruxSigningKey::Ed25519(*key),
-            LibcruxSigningKey::RsaPss { n, d, hash_algo } => LibcruxSigningKey::RsaPss { n: n.clone(), d: d.clone(), hash_algo: *hash_algo },
+            LibcruxSigningKey::RsaPss { n, d, hash_algo } => LibcruxSigningKey::RsaPss {
+                n: n.clone(),
+                d: d.clone(),
+                hash_algo: *hash_algo,
+            },
         }
     }
 }
@@ -187,21 +186,16 @@ impl SigningKey for LibcruxSigningKey {
 impl Signer for LibcruxSigningKey {
     fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
         match self {
-            LibcruxSigningKey::RsaPss {
-                n,
-                d,
-                hash_algo,
-            } => {
+            LibcruxSigningKey::RsaPss { n, d, hash_algo } => {
                 let mut sig = vec![0u8; n.len()];
                 let mut salt = [0u8; 32];
                 rand_core::OsRng.try_fill_bytes(&mut salt).unwrap();
                 let n = n.as_slice();
                 let d = d.as_slice();
 
-                let priv_key =
-                    rsapss::VarLenPrivateKey::from_components(n, d).map_err(|_| {
-                        rustls::Error::General(String::from("error building private key"))
-                    })?;
+                let priv_key = rsapss::VarLenPrivateKey::from_components(n, d).map_err(|_| {
+                    rustls::Error::General(String::from("error building private key"))
+                })?;
                 rsapss::sign_varlen(*hash_algo, &priv_key, message, &salt, sig.as_mut_slice())
                     .map_err(|_| rustls::Error::General(String::from("error signing")))?;
 
@@ -221,9 +215,8 @@ impl Signer for LibcruxSigningKey {
                                 "error der encoding ecdsa signature",
                             ))
                         })
-                    }
-                    // EcdsaSignatureScheme::ECDSA_NISTP384_SHA384 => todo!(),
-                    // EcdsaSignatureScheme::ECDSA_NISTP521_SHA512 => todo!(),
+                    } // EcdsaSignatureScheme::ECDSA_NISTP384_SHA384 => todo!(),
+                      // EcdsaSignatureScheme::ECDSA_NISTP521_SHA512 => todo!(),
                 }
             }
 

--- a/libcrux-provider/src/verify.rs
+++ b/libcrux-provider/src/verify.rs
@@ -1,12 +1,12 @@
 use der::Reader;
 use rustls::crypto::WebPkiSupportedAlgorithms;
-use rustls::pki_types::{alg_id, AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm};
+use rustls::pki_types::{
+    alg_id, AlgorithmIdentifier, InvalidSignature, SignatureVerificationAlgorithm,
+};
 use rustls::SignatureScheme;
-use webpki::{aws_lc_rs::RSA_PKCS1_2048_8192_SHA256 as AWS_LC_RSA_PKCS1_SHA256};
+use webpki::aws_lc_rs::RSA_PKCS1_2048_8192_SHA256 as AWS_LC_RSA_PKCS1_SHA256;
 
-use libcrux::algorithms::ecdsa;
-use libcrux::algorithms::ed25519;
-use libcrux::algorithms::rsapss;
+use libcrux::algorithms::{ecdsa, ed25519, rsapss};
 
 pub static ALGORITHMS: WebPkiSupportedAlgorithms = WebPkiSupportedAlgorithms {
     all: &[
@@ -55,25 +55,12 @@ impl SignatureVerificationAlgorithm for EcdsaP256Verify {
         signature: &[u8],
     ) -> Result<(), InvalidSignature> {
         let mut decoder = der::SliceReader::new(signature).map_err(|_| InvalidSignature)?;
-        let sig: DerEcdsaSignature = decoder
-            .decode()
-            .map_err(|_| InvalidSignature)?;
-        let r: [u8; 32] = sig
-            .r
-            .as_bytes()
-            .try_into()
-            .map_err(|_| InvalidSignature)?;
-        let s: [u8; 32] = sig
-            .s
-            .as_bytes()
-            .try_into()
-            .map_err(|_| InvalidSignature)?;
-        let signature = ecdsa::p256::Signature::from_raw(
-            r,
-            s,
-        );
-        let public_key = ecdsa::p256::PublicKey::try_from(public_key)
-            .map_err(|_| InvalidSignature)?;
+        let sig: DerEcdsaSignature = decoder.decode().map_err(|_| InvalidSignature)?;
+        let r: [u8; 32] = sig.r.as_bytes().try_into().map_err(|_| InvalidSignature)?;
+        let s: [u8; 32] = sig.s.as_bytes().try_into().map_err(|_| InvalidSignature)?;
+        let signature = ecdsa::p256::Signature::from_raw(r, s);
+        let public_key =
+            ecdsa::p256::PublicKey::try_from(public_key).map_err(|_| InvalidSignature)?;
         let alg = ecdsa::DigestAlgorithm::Sha256;
         ecdsa::p256::verify(alg, message, &signature, &public_key).map_err(|_| InvalidSignature)
     }
@@ -151,9 +138,7 @@ fn decode_spki_spk(spki_spk: &[u8]) -> Result<rsapss::VarLenPublicKey<'_>, Inval
     // public_key: unfortunately this is not a whole SPKI, but just the key material.
     // decode the two integers manually.
     let mut reader = der::SliceReader::new(spki_spk).map_err(|_| InvalidSignature)?;
-    let ne: [der::asn1::UintRef; 2] = reader
-        .decode()
-        .map_err(|_| InvalidSignature)?;
+    let ne: [der::asn1::UintRef; 2] = reader.decode().map_err(|_| InvalidSignature)?;
 
     let n = ne[0].as_bytes();
     let e = ne[1].as_bytes();


### PR DESCRIPTION
Hello everyone,

this PR uses the HKDF implementation exported by libcrux in favor of the generic rustls implementation based on an HMAC. This gives libcrux more flexibility on how to implement the HKDF.

I am happy to receive feedback on the changes!