### PR TITLE
Bump dependencies and fix regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["libcrux-provider", "demo-server"]
+members = ["demo-server", "libcrux-provider"]
 
 resolver = "2"
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,15 +1,88 @@
 # A libcrux-backed crypto provider for Rustls
 
-This library implements the crypto provider traits from Rustls, allowing to use
-verified cryptography for TLS connections. The demo server injects a libcrux-enabled
-Rustls config into actix-web to provide an example HTTPS server.
+This library implements the crypto provider traits from [Rustls](https://github.com/rustls/rustls),
+allowing TLS connections to be backed by the verified cryptography in
+[libcrux](https://github.com/cryspen/libcrux). The demo server injects a
+libcrux-enabled Rustls config into actix-web to provide an example HTTPS server.
+
+## Workspace layout
+
+- **`libcrux-provider/`** — the crypto provider crate (`rustls-libcrux-provider`),
+  plus runnable `client` / `server` examples and integration tests.
+- **`demo-server/`** — an actix-web HTTPS server that uses the provider and renders
+  the negotiated key-exchange group (including the post-quantum hybrid) on its
+  landing page.
+- **`tests/`** — ready-made ECDSA and RSA certificate/key fixtures and convenience
+  scripts for the demo server.
+
+## What's supported
+
+- **Protocols:** TLS 1.3 and TLS 1.2
+- **Cipher suite:** ChaCha20-Poly1305
+- **Key exchange:** X25519 and X25519MLKEM768 (post-quantum hybrid)
+- **Signing (server):** ECDSA-P256, Ed25519, RSA-PSS
+- **Signature verification:** ECDSA-P256, Ed25519, RSA-PSS, and RSA-PKCS#1v1.5
+
+## Build & test
+
+```sh
+cargo build --workspace
+cargo test -p rustls-libcrux-provider
+```
+
+The integration tests in
+[`libcrux-provider/tests/handshake.rs`](libcrux-provider/tests/handshake.rs) run
+full in-memory handshakes (plus an application-data round-trip) with the provider on
+both ends, covering the ECDSA/RSA signing paths, TLS 1.2 and TLS 1.3, and each
+key-exchange group.
+
+## Examples
+
+A client that fetches a file over TLS (from `raw.githubusercontent.com`) using the
+provider for all cryptography:
+
+```sh
+cargo run -p rustls-libcrux-provider --example client
+```
+
+A minimal TLS server (generates its own self-signed ECDSA cert, listens on
+`[::]:4443`):
+
+```sh
+cargo run -p rustls-libcrux-provider --example server
+```
+
+## Running the demo server
+
+The demo server takes three arguments: the bind address(es), a PEM certificate
+chain, and a PEM private key. Ready-made fixtures live in `tests/`. From the repo
+root:
+
+```sh
+# ECDSA certificate
+cargo run -p rustls-libcrux-demo-server -- 127.0.0.1:1024 tests/cert_ecdsa.pem tests/key_ecdsa.pem
+
+# or an RSA certificate
+cargo run -p rustls-libcrux-demo-server -- 127.0.0.1:1024 tests/cert_rsa.pem tests/key_rsa.pem
+```
+
+Then open <https://127.0.0.1:1024/> in a browser. The certificates are self-signed,
+so expect (and accept) a certificate warning. The page reports the negotiated
+key-exchange group — modern browsers will show the `X25519MLKEM768` hybrid.
+
+You can pass multiple comma-separated bind addresses, e.g.
+`127.0.0.1:1024,[::1]:1024`.
+
+The [`tests/test_ecdsa.sh`](tests/test_ecdsa.sh) and
+[`tests/test_rsa.sh`](tests/test_rsa.sh) scripts wrap the commands above; run them
+from inside the `tests/` directory (they use paths relative to it).
 
 ## Creating a libcrux-enabled Rustls server config
 
-This is a simple example for building a config for a Rustls server:
+A minimal example for building a Rustls `ServerConfig` backed by this provider:
 
 ```rust
-    // You have to do these yourself. The demo server has code to load_key PEM files.
+    // You have to do these yourself. The demo server has code to load PEM files.
     let certs: Vec<CertificateDer> = load_certs();
     let private_key: PrivateKeyDer = load_key();
 

--- a/demo-server/Cargo.toml
+++ b/demo-server/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
+edition = "2021"
 name = "rustls-libcrux-demo-server"
 version = "0.1.0"
-edition = "2021"
 
 [dependencies]
-actix-tls = { version = "3.4.0", features = ["rustls-0_23"] }
-actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
-rustls = "0.23.18"
+actix-tls = { version = "3.5.0", features = ["rustls-0_23"] }
+actix-web = { version = "4.14.0", features = ["rustls-0_23"] }
+env_logger = "0.11.11"
+handlebars = "6.4.3"
+log = "0.4.33"
+rustls = "0.23.42"
 rustls-libcrux-provider = { workspace = true }
-log = "0.4.22"
-env_logger = "0.11.5"
-handlebars = "6.2.0"
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0.229", features = ["derive"] }

--- a/libcrux-provider/Cargo.toml
+++ b/libcrux-provider/Cargo.toml
@@ -1,32 +1,32 @@
 [package]
-name = "rustls-libcrux-provider"
-version = "0.0.1"
+description = "A rustls crypto provider based on libcrux."
 edition = "2021"
 license = "Apache-2.0 OR ISC OR MIT"
-description = "A rustls crypto provider based on libcrux."
+name = "rustls-libcrux-provider"
+version = "0.0.1"
 
 [dependencies]
-rustls = { version = "0.23.36" }
+rustls = { version = "0.23.42" }
 
-libcrux = "0.0.3"
-libcrux-traits = "0.0.6"
+libcrux = "0.0.5"
+libcrux-traits = "0.0.8"
 
-hpke-rs = { version = "0.5", features = ["hazmat"]}
+hpke-rs = { version = "0.7", features = ["hazmat"] }
 
-der = "0.7"
-pkcs8 = "0.10.2"
+der = "0.8"
 pkcs1 = "0.7.5"
+pkcs8 = "0.11.0"
 pki-types = { package = "rustls-pki-types", version = "1" }
-rand_core = { version = "0.9", features = ["os_rng"] }
-sec1 = { version = "0.7.3" }
+rand = { version = "0.10", features = ["sys_rng"] }
+sec1 = { version = "0.8.1" }
 webpki = { package = "rustls-webpki", version = "0.103", features = [
-    "alloc", 
+    "alloc",
 ], default-features = false }
 
 [dev-dependencies]
 env_logger = "0.11"
-rcgen = { version = "0.13", features = ["aws_lc_rs"] }
-webpki-roots = "0.26"
+rcgen = { version = "0.14", features = ["aws_lc_rs"] }
+webpki-roots = "1.0"
 
 [features]
 default = ["std"]

--- a/libcrux-provider/examples/server.rs
+++ b/libcrux-provider/examples/server.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 use std::sync::Arc;
 
+use rcgen::Issuer;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::server::Acceptor;
 use rustls::ServerConfig;
@@ -71,7 +72,6 @@ impl TestPki {
             rcgen::KeyUsagePurpose::DigitalSignature,
         ];
         let ca_key = rcgen::KeyPair::generate_for(alg).unwrap();
-        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
 
         // Create a server end entity cert issued by the CA.
         let mut server_ee_params =
@@ -80,7 +80,7 @@ impl TestPki {
         server_ee_params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ServerAuth];
         let server_key = rcgen::KeyPair::generate_for(alg).unwrap();
         let server_cert = server_ee_params
-            .signed_by(&server_key, &ca_cert, &ca_key)
+            .signed_by(&server_key, &Issuer::new(ca_params, ca_key))
             .unwrap();
         Self {
             server_cert_der: server_cert.into(),

--- a/libcrux-provider/src/aead.rs
+++ b/libcrux-provider/src/aead.rs
@@ -13,7 +13,7 @@ use rustls::{
 };
 
 use libcrux::algorithms::chacha20poly1305;
-use libcrux::{algorithms::aes_gcm::Aead, primitives::aead};
+use libcrux::{algorithms::aes_aead::Aead, primitives::aead};
 
 pub enum LibcruxAeadKey {
     Chacha20Poly1305([u8; chacha20poly1305::KEY_LEN]),
@@ -220,6 +220,7 @@ impl MessageEncrypter for Tls12Cipher {
 
         let mut payload = PrefixedPayload::with_capacity(total_len);
         payload.extend_from_slice(&ciphertext);
+        payload.extend_from_slice(tag.as_ref());
 
         Ok(OutboundOpaqueMessage::new(m.typ, m.version, payload))
     }
@@ -251,12 +252,9 @@ impl MessageDecrypter for Tls12Cipher {
 
         let (payload, tag) = payload_and_tag.split_at_mut(payload_and_tag_len - tag_len);
         let nonce = Nonce::new(&self.1, seq);
-        let aad = make_tls12_aad(
-            seq,
-            m.typ,
-            m.version,
-            payload.len() - CHACHAPOLY1305_OVERHEAD,
-        );
+        // `payload` is already the tag-stripped ciphertext, whose length equals the
+        // plaintext length — matching what the encrypter passes as the AAD length.
+        let aad = make_tls12_aad(seq, m.typ, m.version, payload.len());
         let mut plaintext = vec![0u8; payload.len()];
 
         let tag = aead::TagRef::new_for_algo(*key.algo(), tag)

--- a/libcrux-provider/src/hkdf.rs
+++ b/libcrux-provider/src/hkdf.rs
@@ -69,4 +69,3 @@ impl crypto::tls13::HkdfExpander for Sha256HKDFKey {
         SHA2_256_LEN
     }
 }
-

--- a/libcrux-provider/src/kx.rs
+++ b/libcrux-provider/src/kx.rs
@@ -4,7 +4,7 @@ use alloc::string::String;
 use libcrux::algorithms::curve25519;
 
 use libcrux_traits::ecdh::owned::EcdhOwned;
-use rand_core::TryRngCore;
+use rand::TryRng as _;
 use rustls::crypto::{self, SupportedKxGroup as _};
 
 use crate::pq::X25519MlKem768;
@@ -48,7 +48,7 @@ pub struct X25519;
 impl crypto::SupportedKxGroup for X25519 {
     fn start(&self) -> Result<Box<dyn crypto::ActiveKeyExchange>, rustls::Error> {
         let mut rand: [u8; 32] = [0u8; 32];
-        rand_core::OsRng
+        rand::rngs::SysRng
             .try_fill_bytes(&mut rand)
             .map_err(|_| rustls::Error::FailedToGetRandomBytes)?;
         let (pub_key, priv_key) = curve25519::X25519::generate_pair(&rand)

--- a/libcrux-provider/src/lib.rs
+++ b/libcrux-provider/src/lib.rs
@@ -6,6 +6,7 @@ extern crate std;
 
 use alloc::sync::Arc;
 
+use rand::TryRng as _;
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::PrivateKeyDer;
 
@@ -35,8 +36,7 @@ struct Provider;
 
 impl rustls::crypto::SecureRandom for Provider {
     fn fill(&self, bytes: &mut [u8]) -> Result<(), rustls::crypto::GetRandomFailed> {
-        use rand_core::TryRngCore;
-        rand_core::OsRng
+        rand::rngs::SysRng
             .try_fill_bytes(bytes)
             .map_err(|_| rustls::crypto::GetRandomFailed)
     }

--- a/libcrux-provider/src/pq.rs
+++ b/libcrux-provider/src/pq.rs
@@ -3,7 +3,7 @@ use core::convert::TryFrom;
 use libcrux::algorithms::mlkem;
 
 use alloc::{boxed::Box, vec, vec::Vec};
-use rand_core::TryRngCore;
+use rand::TryRng as _;
 use rustls::{
     crypto::{ActiveKeyExchange, CompletedKeyExchange, SharedSecret, SupportedKxGroup},
     ffdhe_groups::FfdheGroup,
@@ -21,7 +21,7 @@ impl SupportedKxGroup for X25519MlKem768 {
         let x25519 = crate::kx::X25519.start()?;
 
         let mut rand = [0u8; mlkem::KEY_GENERATION_SEED_SIZE];
-        rand_core::OsRng.try_fill_bytes(&mut rand).unwrap();
+        rand::rngs::SysRng.try_fill_bytes(&mut rand).unwrap();
         let ml_kem = mlkem::mlkem768::generate_key_pair(rand);
 
         let mut combined_pub_key = Vec::with_capacity(COMBINED_PUBKEY_LEN);
@@ -43,7 +43,7 @@ impl SupportedKxGroup for X25519MlKem768 {
         let x25519 = crate::kx::X25519.start_and_complete(share.x25519)?;
 
         let mut rand = [0u8; mlkem::ENCAPS_SEED_SIZE];
-        rand_core::OsRng.try_fill_bytes(&mut rand).unwrap();
+        rand::rngs::SysRng.try_fill_bytes(&mut rand).unwrap();
 
         let pk = mlkem::mlkem768::MlKem768PublicKey::try_from(share.ml_kem)
             .map_err(|_| INVALID_KEY_SHARE)?;

--- a/libcrux-provider/src/sign.rs
+++ b/libcrux-provider/src/sign.rs
@@ -1,19 +1,18 @@
-use std::vec;
-
 use alloc::boxed::Box;
 use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 
 use der::oid::Arc as OidArc;
-use der::{Decode, Tag, Tagged};
-use pkcs8::ObjectIdentifier;
-use rand_core::TryRngCore;
+use der::{Encode, Tag, Tagged};
+use pkcs8::{DecodePrivateKey, KeyError, ObjectIdentifier};
+use rand::rand_core::UnwrapErr;
+use rand::TryRng as _;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::sign::{Signer, SigningKey};
 use rustls::{SignatureAlgorithm, SignatureScheme};
 use sec1::EcPrivateKey;
 
-use der::{asn1::UintRef, Encode};
+use der::asn1::UintRef;
 
 use libcrux::algorithms::{ecdsa, ed25519, rsapss};
 
@@ -46,7 +45,9 @@ impl TryFrom<PrivateKeyDer<'_>> for LibcruxSigningKey {
     fn try_from(value: PrivateKeyDer<'_>) -> Result<Self, Self::Error> {
         match value {
             PrivateKeyDer::Pkcs8(der) => {
-                let private_key_info = pkcs8::PrivateKeyInfo::try_from(der.secret_pkcs8_der())?;
+                let private_key_info =
+                    pkcs8::PrivateKeyInfoOwned::from_pkcs8_der(der.secret_pkcs8_der())
+                        .map_err(|_| pkcs8::Error::KeyMalformed(KeyError::Invalid))?;
                 let algo_oid_arcs: Vec<OidArc> = private_key_info.algorithm.oid.arcs().collect();
 
                 match algo_oid_arcs.as_slice() {
@@ -55,9 +56,9 @@ impl TryFrom<PrivateKeyDer<'_>> for LibcruxSigningKey {
                         let parameter = private_key_info
                             .algorithm
                             .parameters
-                            .ok_or(pkcs8::Error::KeyMalformed)?;
+                            .ok_or(pkcs8::Error::KeyMalformed(KeyError::Invalid))?;
                         if parameter.tag() != Tag::ObjectIdentifier {
-                            return Err(pkcs8::Error::KeyMalformed);
+                            return Err(pkcs8::Error::KeyMalformed(KeyError::Invalid));
                         }
 
                         let parameter_oid =
@@ -66,40 +67,43 @@ impl TryFrom<PrivateKeyDer<'_>> for LibcruxSigningKey {
 
                         let (key, scheme) = match parameter_oid_arcs.as_slice() {
                             [1, 2, 840, 10045, 3, 1, 7] => {
-                                let key = private_key_info.private_key;
-                                let key: ecdsa::p256::PrivateKey = EcPrivateKey::try_from(key)
-                                    .map_err(|_| pkcs8::Error::KeyMalformed)?
-                                    .private_key
-                                    .try_into()
-                                    .map_err(|_| pkcs8::Error::KeyMalformed)?;
+                                let key_bytes = private_key_info.private_key.as_bytes();
+                                let key: ecdsa::p256::PrivateKey =
+                                    EcPrivateKey::try_from(key_bytes)
+                                        .map_err(|_| pkcs8::Error::KeyMalformed(KeyError::Invalid))?
+                                        .private_key
+                                        .try_into()
+                                        .map_err(|_| {
+                                            pkcs8::Error::KeyMalformed(KeyError::Invalid)
+                                        })?;
 
                                 (key, EcdsaSignatureScheme::ECDSA_NISTP256_SHA256)
                             }
                             // [1, 3, 132, 0, 34] => EcdsaSignatureScheme::ECDSA_NISTP384_SHA384,
                             // [1, 3, 132, 0, 35] => EcdsaSignatureScheme::ECDSA_NISTP521_SHA512,
-                            _ => return Err(pkcs8::Error::KeyMalformed),
+                            _ => return Err(pkcs8::Error::KeyMalformed(KeyError::Invalid)),
                         };
 
                         Ok(Self::Ecdsa(key, scheme))
                     }
                     // `rsaEncryption` from RFC3279 / PKCS#1
                     [1, 2, 840, 113549, 1, 1, 1] => {
-                        let mut decoder = der::SliceReader::new(private_key_info.private_key)?;
-                        let rsa_priv_key = pkcs1::RsaPrivateKey::decode(&mut decoder)?;
+                        // `pkcs1` uses der 0.7, so decode from the raw key bytes with its
+                        // own reader rather than passing our der 0.8 decoder.
+                        let key_bytes = private_key_info.private_key.as_bytes();
+                        let rsa_priv_key = pkcs1::RsaPrivateKey::try_from(key_bytes)
+                            .map_err(|_| pkcs8::Error::KeyMalformed(KeyError::Invalid))?;
 
                         if !matches!(rsa_priv_key.public_exponent.as_bytes(), [1, 0, 1]) {
                             return Err(pkcs8::Error::ParametersMalformed);
                         }
 
-                        let n = rsa_priv_key.modulus.as_bytes();
-                        let n = trim_leading_zeroes(n).to_vec();
-
-                        let d = rsa_priv_key.private_exponent.as_bytes();
-                        let d = trim_leading_zeroes(d).to_vec();
-
-                        // let pub_key =
-                        //     signature::rsa_pss::RsaPssPublicKey::new(key_size, &n).unwrap();
-                        // let priv_key = signature::rsa_pss::RsaPssPrivateKey::new(&pub_key, &d);
+                        // `n` (the modulus) fixes the key length; left-pad `d` (always < n)
+                        // to match, since libcrux's `from_components` requires equal lengths.
+                        let n = rsa_priv_key.modulus.as_bytes().to_vec();
+                        let d_bytes = rsa_priv_key.private_exponent.as_bytes();
+                        let mut d = vec![0u8; n.len()];
+                        d[n.len() - d_bytes.len()..].copy_from_slice(d_bytes);
 
                         Ok(Self::RsaPss {
                             n,
@@ -107,23 +111,12 @@ impl TryFrom<PrivateKeyDer<'_>> for LibcruxSigningKey {
                             hash_algo: rsapss::DigestAlgorithm::Sha2_256,
                         })
                     }
-                    _ => Err(pkcs8::Error::KeyMalformed),
+                    _ => Err(pkcs8::Error::KeyMalformed(KeyError::Invalid)),
                 }
             }
-            _ => Err(pkcs8::Error::KeyMalformed),
+            _ => Err(pkcs8::Error::KeyMalformed(KeyError::Invalid)),
         }
     }
-}
-
-fn trim_leading_zeroes(mut buf: &[u8]) -> &[u8] {
-    while let Some(leading) = buf.first() {
-        if *leading == 0 {
-            buf = &buf[481..];
-        } else {
-            break;
-        }
-    }
-    buf
 }
 
 impl core::fmt::Debug for LibcruxSigningKey {
@@ -189,7 +182,9 @@ impl Signer for LibcruxSigningKey {
             LibcruxSigningKey::RsaPss { n, d, hash_algo } => {
                 let mut sig = vec![0u8; n.len()];
                 let mut salt = [0u8; 32];
-                rand_core::OsRng.try_fill_bytes(&mut salt).unwrap();
+                rand::rngs::SysRng.try_fill_bytes(&mut salt).map_err(|_| {
+                    rustls::Error::General(String::from("error generating random salt"))
+                })?;
                 let n = n.as_slice();
                 let d = d.as_slice();
 
@@ -205,8 +200,9 @@ impl Signer for LibcruxSigningKey {
             LibcruxSigningKey::Ecdsa(private_key, scheme) => {
                 match scheme {
                     EcdsaSignatureScheme::ECDSA_NISTP256_SHA256 => {
+                        let mut rng = UnwrapErr(rand::rngs::SysRng);
                         let alg = ecdsa::DigestAlgorithm::Sha256;
-                        let nonce = ecdsa::p256::Nonce::random(&mut rand_core::OsRng.unwrap_mut())
+                        let nonce = ecdsa::p256::Nonce::random(&mut rng)
                             .map_err(|_| rustls::Error::General(String::from("signing error")))?;
                         let sig = ecdsa::p256::sign(alg, message, private_key, &nonce)
                             .map_err(|_| rustls::Error::General(String::from("signing error")))?;

--- a/libcrux-provider/src/verify.rs
+++ b/libcrux-provider/src/verify.rs
@@ -56,8 +56,8 @@ impl SignatureVerificationAlgorithm for EcdsaP256Verify {
     ) -> Result<(), InvalidSignature> {
         let mut decoder = der::SliceReader::new(signature).map_err(|_| InvalidSignature)?;
         let sig: DerEcdsaSignature = decoder.decode().map_err(|_| InvalidSignature)?;
-        let r: [u8; 32] = sig.r.as_bytes().try_into().map_err(|_| InvalidSignature)?;
-        let s: [u8; 32] = sig.s.as_bytes().try_into().map_err(|_| InvalidSignature)?;
+        let r = scalar_to_fixed_32(sig.r.as_bytes())?;
+        let s = scalar_to_fixed_32(sig.s.as_bytes())?;
         let signature = ecdsa::p256::Signature::from_raw(r, s);
         let public_key =
             ecdsa::p256::PublicKey::try_from(public_key).map_err(|_| InvalidSignature)?;
@@ -135,20 +135,48 @@ impl SignatureVerificationAlgorithm for RsaPssVerify {
 }
 
 fn decode_spki_spk(spki_spk: &[u8]) -> Result<rsapss::VarLenPublicKey<'_>, InvalidSignature> {
-    // public_key: unfortunately this is not a whole SPKI, but just the key material.
-    // decode the two integers manually.
+    // public_key: unfortunately this is not a whole SPKI, but just the key material,
+    // i.e. an `RSAPublicKey ::= SEQUENCE { modulus INTEGER, publicExponent INTEGER }`.
+    // Decode the SEQUENCE and extract the two integers.
     let mut reader = der::SliceReader::new(spki_spk).map_err(|_| InvalidSignature)?;
-    let ne: [der::asn1::UintRef; 2] = reader.decode().map_err(|_| InvalidSignature)?;
+    let (n, e) = reader
+        .sequence(|reader| {
+            let n: der::asn1::UintRef = reader.decode()?;
+            let e: der::asn1::UintRef = reader.decode()?;
+            Ok::<_, der::Error>((n, e))
+        })
+        .map_err(|_| InvalidSignature)?;
 
-    let n = ne[0].as_bytes();
-    let e = ne[1].as_bytes();
+    let n_bytes = n.as_bytes();
+    let e_bytes = e.as_bytes();
 
-    if !matches!(e, [1, 0, 1]) {
+    if !matches!(e_bytes, [1, 0, 1]) {
         // it's actually a NotSupportedError, but it amounts to the same
         return Err(InvalidSignature);
     }
 
-    rsapss::VarLenPublicKey::try_from(n).map_err(|_| InvalidSignature)
+    rsapss::VarLenPublicKey::try_from(n_bytes).map_err(|_| InvalidSignature)
+}
+
+/// Normalize a DER INTEGER's content bytes into a fixed-length 32-byte
+/// big-endian scalar, as required by the raw P256 signature representation.
+///
+/// DER INTEGER encoding may prepend a `0x00` sign byte when the high bit is
+/// set (making the content 33 bytes) or omit leading zero bytes for small
+/// values (making it shorter). Both cases must be normalized back to exactly
+/// 32 bytes, otherwise the signature is spuriously rejected.
+fn scalar_to_fixed_32(bytes: &[u8]) -> Result<[u8; 32], InvalidSignature> {
+    // Strip a single leading zero sign byte, if present.
+    let bytes = match bytes {
+        [0x00, rest @ ..] => rest,
+        other => other,
+    };
+    if bytes.len() > 32 {
+        return Err(InvalidSignature);
+    }
+    let mut out = [0u8; 32];
+    out[32 - bytes.len()..].copy_from_slice(bytes);
+    Ok(out)
 }
 
 struct DerEcdsaSignature {
@@ -157,7 +185,9 @@ struct DerEcdsaSignature {
 }
 
 impl<'a> der::Decode<'a> for DerEcdsaSignature {
-    fn decode<R: Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
+    type Error = der::Error;
+
+    fn decode<R: der::Reader<'a>>(decoder: &mut R) -> der::Result<Self> {
         decoder.sequence(|decoder| {
             Ok(Self {
                 r: decoder.decode()?,

--- a/libcrux-provider/tests/handshake.rs
+++ b/libcrux-provider/tests/handshake.rs
@@ -1,0 +1,218 @@
+//! In-memory TLS handshakes exercising the libcrux provider on BOTH ends.
+//!
+//! These drive the signing paths (server) and verification paths (client) that the
+//! public `client` example (a single RSA server over TLS 1.3) can't cover on its
+//! own: the ECDSA signature path, the TLS 1.2 cipher/handshake path, the AEAD
+//! encrypt+decrypt of application data, and each key-exchange group.
+
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use rcgen::Issuer;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+use rustls::{
+    ClientConfig, ClientConnection, ConnectionCommon, NamedGroup, RootCertStore, ServerConfig,
+    ServerConnection, SupportedProtocolVersion,
+};
+
+struct Pki {
+    ca_cert: CertificateDer<'static>,
+    server_cert: CertificateDer<'static>,
+    server_key: PrivateKeyDer<'static>,
+}
+
+fn make_pki(alg: &'static rcgen::SignatureAlgorithm) -> Pki {
+    let mut ca_params = rcgen::CertificateParams::new(Vec::new()).unwrap();
+    ca_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "Test CA");
+    ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![
+        rcgen::KeyUsagePurpose::KeyCertSign,
+        rcgen::KeyUsagePurpose::DigitalSignature,
+    ];
+    let ca_key = rcgen::KeyPair::generate_for(alg).unwrap();
+    let ca_cert = ca_params.clone().self_signed(&ca_key).unwrap();
+
+    let mut ee_params = rcgen::CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+    ee_params.is_ca = rcgen::IsCa::NoCa;
+    ee_params.extended_key_usages = vec![rcgen::ExtendedKeyUsagePurpose::ServerAuth];
+    let server_key = rcgen::KeyPair::generate_for(alg).unwrap();
+    let server_cert = ee_params
+        .signed_by(&server_key, &Issuer::new(ca_params, ca_key))
+        .unwrap();
+
+    Pki {
+        ca_cert: ca_cert.into(),
+        server_cert: server_cert.into(),
+        server_key: PrivatePkcs8KeyDer::from(server_key.serialize_der()).into(),
+    }
+}
+
+struct Opts<'a> {
+    /// Protocol versions offered by both peers.
+    versions: &'a [&'static SupportedProtocolVersion],
+    /// If set, restrict the provider to only this key-exchange group and assert it
+    /// was the one negotiated.
+    kx: Option<NamedGroup>,
+}
+
+/// Build a provider, optionally restricting it to a single key-exchange group. The
+/// concrete kx types are private to the crate, so we filter the public list on the
+/// `SupportedKxGroup::name()` trait method instead.
+fn provider(kx: Option<NamedGroup>) -> rustls::crypto::CryptoProvider {
+    let mut provider = rustls_libcrux_provider::provider();
+    if let Some(want) = kx {
+        provider.kx_groups.retain(|g| g.name() == want);
+        assert!(
+            !provider.kx_groups.is_empty(),
+            "kx group {want:?} not supported"
+        );
+    }
+    provider
+}
+
+/// Move all currently-pending TLS records from `from` to `to` and process them.
+/// Both connection ends deref to `ConnectionCommon<Data>`, so this is generic over it.
+fn transfer<A, B>(from: &mut ConnectionCommon<A>, to: &mut ConnectionCommon<B>) {
+    let mut buf = Vec::new();
+    from.write_tls(&mut buf).unwrap();
+    if !buf.is_empty() {
+        to.read_tls(&mut &buf[..]).unwrap();
+        to.process_new_packets().expect("peer rejected records");
+    }
+}
+
+/// Full in-memory handshake with the libcrux provider on both peers, followed by a
+/// bidirectional application-data round-trip. Asserts the client accepts the
+/// server's signature, the negotiated version/kx match expectations, and that AEAD
+/// encrypt/decrypt round-trips in both directions.
+fn run_handshake(pki: Pki, opts: Opts<'_>) {
+    let server_config = ServerConfig::builder_with_provider(Arc::new(provider(opts.kx)))
+        .with_protocol_versions(opts.versions)
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(vec![pki.server_cert.clone()], pki.server_key)
+        .unwrap();
+
+    let mut roots = RootCertStore::empty();
+    roots.add(pki.ca_cert).unwrap();
+    let client_config = ClientConfig::builder_with_provider(Arc::new(provider(opts.kx)))
+        .with_protocol_versions(opts.versions)
+        .unwrap()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    let server_name: ServerName = "localhost".try_into().unwrap();
+    let mut client = ClientConnection::new(Arc::new(client_config), server_name).unwrap();
+    let mut server = ServerConnection::new(Arc::new(server_config)).unwrap();
+
+    // Pump until both have finished handshaking. `&mut *conn` derefs the concrete
+    // connection to the `ConnectionCommon` the generic helpers expect.
+    let mut done = false;
+    for _ in 0..20 {
+        transfer(&mut client, &mut server);
+        transfer(&mut server, &mut client);
+        if !client.is_handshaking() && !server.is_handshaking() {
+            done = true;
+            break;
+        }
+    }
+    assert!(done, "handshake did not complete");
+
+    // The negotiated parameters document what this test actually exercised.
+    if opts.versions.len() == 1 {
+        assert_eq!(
+            client.protocol_version(),
+            Some(opts.versions[0].version),
+            "unexpected negotiated protocol version"
+        );
+    }
+    if let Some(want) = opts.kx {
+        assert_eq!(
+            client.negotiated_key_exchange_group().map(|g| g.name()),
+            Some(want),
+            "unexpected negotiated key-exchange group"
+        );
+    }
+
+    // Application-data round-trip in both directions (exercises AEAD encrypt+decrypt).
+    round_trip(&mut client, &mut server, b"ping from client");
+    round_trip(&mut server, &mut client, b"pong from server");
+}
+
+/// Send `msg` from `sender` and assert `receiver` reads back exactly the same bytes.
+fn round_trip<A, B>(
+    sender: &mut ConnectionCommon<A>,
+    receiver: &mut ConnectionCommon<B>,
+    msg: &[u8],
+) {
+    sender.writer().write_all(msg).unwrap();
+    sender.writer().flush().unwrap();
+    transfer(sender, receiver);
+
+    let mut buf = vec![0u8; msg.len()];
+    receiver.reader().read_exact(&mut buf).unwrap();
+    assert_eq!(buf, msg, "application data did not round-trip");
+}
+
+#[test]
+fn tls13_ecdsa() {
+    // ECDSA P256 signing (sign.rs) + verification with r/s normalization (verify.rs).
+    run_handshake(
+        make_pki(&rcgen::PKCS_ECDSA_P256_SHA256),
+        Opts {
+            versions: &[&rustls::version::TLS13],
+            kx: None,
+        },
+    );
+}
+
+#[test]
+fn tls13_rsa() {
+    // RSA private-key decoding (sign.rs) + RSA-PSS SPKI decoding (verify.rs).
+    run_handshake(
+        make_pki(&rcgen::PKCS_RSA_SHA256),
+        Opts {
+            versions: &[&rustls::version::TLS13],
+            kx: None,
+        },
+    );
+}
+
+#[test]
+fn tls12_rsa() {
+    // The TLS 1.2 suite is RSA-only for signing, and drives the separate Tls12Cipher
+    // (aead.rs) and PRF handshake path.
+    run_handshake(
+        make_pki(&rcgen::PKCS_RSA_SHA256),
+        Opts {
+            versions: &[&rustls::version::TLS12],
+            kx: None,
+        },
+    );
+}
+
+#[test]
+fn tls13_x25519() {
+    // Pure X25519 key exchange (kx.rs).
+    run_handshake(
+        make_pki(&rcgen::PKCS_ECDSA_P256_SHA256),
+        Opts {
+            versions: &[&rustls::version::TLS13],
+            kx: Some(NamedGroup::X25519),
+        },
+    );
+}
+
+#[test]
+fn tls13_x25519mlkem768() {
+    // Hybrid post-quantum key exchange (pq.rs), touched by the rand migration.
+    run_handshake(
+        make_pki(&rcgen::PKCS_ECDSA_P256_SHA256),
+        Opts {
+            versions: &[&rustls::version::TLS13],
+            kx: Some(NamedGroup::X25519MLKEM768),
+        },
+    );
+}


### PR DESCRIPTION
Update to der 0.8, pkcs8 0.11, rand 0.10, libcrux 0.0.5, rcgen 0.14, hpke-rs 0.7, webpki-roots 1.0, and migrate to their new APIs.

Fix breakage surfaced by the upgrade and by new tests:
- verify: decode the RSAPublicKey SEQUENCE wrapper in decode_spki_spk (der 0.8 no longer implies it via [UintRef; 2]); the missing unwrap made every RSA-PSS CertificateVerify fail with BadSignature.
- verify: normalize ECDSA r/s to fixed 32-byte scalars, since der 0.8 Int::as_bytes returns raw content (leading sign byte / short values).
- sign: decode RSA keys via pkcs1 again and left-pad d to the modulus length, as libcrux from_components requires n.len() == d.len().
- aead: append the auth tag in the TLS 1.2 encrypter and stop double-subtracting the tag length in the decrypter (underflow panic).

Add in-memory handshake tests covering ECDSA/RSA, TLS 1.2/1.3, each key-exchange group, and an application-data round-trip. Expand the README with build/test, examples, and demo-server usage.